### PR TITLE
Fix issue with .net core 2.0 with wrong folder structure

### DIFF
--- a/src/NSwag.MSBuild/NSwag.MSBuild.nuspec
+++ b/src/NSwag.MSBuild/NSwag.MSBuild.nuspec
@@ -24,6 +24,6 @@
 
     <file src="..\NSwag.ConsoleCore\bin\release\netcoreapp1.0\Publish\*" target="build/netcoreapp1.0" />
     <file src="..\NSwag.ConsoleCore\bin\release\netcoreapp1.1\Publish\*" target="build/netcoreapp1.1" />
-    <file src="..\NSwag.ConsoleCore\bin\release\netcoreapp2.0\Publish\*" target="build/netcoreapp1.2" />
+    <file src="..\NSwag.ConsoleCore\bin\release\netcoreapp2.0\Publish\*" target="build/netcoreapp2.0" />
   </files>
 </package>


### PR DESCRIPTION
I noticed that running these with a .net core 2.0 project wont work.
This was due to a typo in creating the nugget.