### PR TITLE
Fix #956 NSwag.Npm: the package requires npm ^3.10.8

### DIFF
--- a/src/NSwag.Npm/package.json
+++ b/src/NSwag.Npm/package.json
@@ -18,8 +18,8 @@
   "bugs": {
     "url": "https://github.com/NSwag/NSwag/issues"
   },
-  "dependencies": {
-    "npm": "^3.10.8"
+  "peerDependencies": {
+    "npm": ">=3.10.8"
   },
   "description": "The Swagger API toolchain for .NET, Web API and TypeScript.",
   "directories": {},


### PR DESCRIPTION
In the package.json, nswag depends on npm ^3.10.8. The consequence is that npm 3.10.10 is installed locally instead of using the globally installed npm.
It should be a peerDependencies and not a dependencies, and the version should be >=3.10.8