### PR TITLE
Allow environment variables in search path, assemblies

### DIFF
--- a/src/NSwag.AssemblyLoader/AssemblyLoader.cs
+++ b/src/NSwag.AssemblyLoader/AssemblyLoader.cs
@@ -150,6 +150,7 @@ namespace NSwag.AssemblyLoader
 
         private string[] GetAllDirectories(string rootDirectory)
         {
+            rootDirectory = Environment.ExpandEnvironmentVariables(rootDirectory);
             return Directory.GetDirectories(rootDirectory, "*", SearchOption.AllDirectories);
         }
     }


### PR DESCRIPTION
I need to reference assemblies located under my user profile, and the .nswag file needs to be checked into source control. To ensure other members of the team find the same assemblies when they run code generation, I need to use environment variables (%USERPROFILE%) in my search paths.

This doesn't seem to be supported, but the fix should just be a matter of adding one line, as I've done in this pull request.