### PR TITLE
Fix compilation issues of generated Angular client

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript/Templates/AngularClientTemplate.cs
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/AngularClientTemplate.cs
@@ -693,7 +693,7 @@ if(operation.HasBody){
             
             #line default
             #line hidden
-            this.Write("        let options_ = {\r\n");
+            this.Write("        let options_ : any = {\r\n");
             
             #line 61 "C:\Data\Projects\NSwag\src\NSwag.CodeGeneration.TypeScript\Templates\AngularClientTemplate.tt"
 if(operation.HasBody){
@@ -907,7 +907,7 @@ if(Model.UseAngularHttpClient){
             
             #line default
             #line hidden
-            this.Write("url_, options_).flatMap((response_) => {\r\n");
+            this.Write("url_, options_).flatMap((response_ : any) => {\r\n");
             
             #line 92 "C:\Data\Projects\NSwag\src\NSwag.CodeGeneration.TypeScript\Templates\AngularClientTemplate.tt"
 }

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/AngularClientTemplate.tt
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/AngularClientTemplate.tt
@@ -55,9 +55,9 @@ export class <#=Model.Class#> <#if(Model.HasBaseClass){#>extends <#=Model.BaseCl
 
 <#if(operation.HasBody){#>
         <#=TypeScriptTemplatePartGenerator.RenderRequestBodyCode(operation, 2)#>
-        
+
 <#}#>
-        let options_ = {
+        let options_ : any = {
 <#if(operation.HasBody){#>
             body: content_,
 <#}#>
@@ -88,7 +88,7 @@ export class <#=Model.Class#> <#if(Model.HasBaseClass){#>extends <#=Model.BaseCl
             return this.http.request(<#if(Model.UseAngularHttpClient){#>"<#=operation.HttpMethodLower#>", <#}#>url_, transformedOptions_);
         }).flatMap((response_: any) => {
 <#}else{#>
-        return this.http.request(<#if(Model.UseAngularHttpClient){#>"<#=operation.HttpMethodLower#>", <#}#>url_, options_).flatMap((response_) => {
+        return this.http.request(<#if(Model.UseAngularHttpClient){#>"<#=operation.HttpMethodLower#>", <#}#>url_, options_).flatMap((response_ : any) => {
 <#}#>
 <#if(Model.UseTransformResultMethod){#>
             return this.transformResult(url_, response_, (r) => this.process<#=operation.ActualOperationNameUpper#>(r));


### PR DESCRIPTION
Using Angular 4.4.3 and Typescript 2.5.3 the generated Angular client does compile,

For the code snippet below, Typescript is not able to infer the correct type of `options_` (`observe` is 'response' not string and the same for `responseType`).
It fails with:
```
error TS2345: Argument of type '{ body: string; observe: string; responseType:
string; headers: HttpHeaders; }' is not assignable to parameter of type '{ body?:
any; headers?: HttpHeaders; params?: HttpParams; observe?: HttpObserve;
reportProgress?:...'.
  Types of property 'observe' are incompatible.
      Type 'string' is not assignable to type 'HttpObserve'.
```

```
        let options_ = {
            observe: "response",
            responseType: "blob",
            headers: new HttpHeaders({
                "Content-Type": "application/json",
            })
        };

        return this.http.request("get", url_, options_).flatMap((response_) => {
```

