### PR TITLE
Introduce seperator for StringArrayConverter, Fixes #1013

### DIFF
--- a/src/NSwagStudio/Converters/StringArrayConverter.cs
+++ b/src/NSwagStudio/Converters/StringArrayConverter.cs
@@ -9,14 +9,24 @@ namespace NSwagStudio.Converters
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            return value != null ? string.Join("\n", (string[])value) : string.Empty;
+            string seperator = "\n";
+            if (parameter != null)
+            {
+                seperator = (string)parameter;
+            }
+            return value != null ? string.Join(seperator, (string[])value) : string.Empty;
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
+            char seperator = '\n';
+            if (parameter != null)
+            {
+                seperator = System.Convert.ToChar(parameter);
+            }
             return value?.ToString()
                 .Trim('\r')
-                .Split('\n')
+                .Split(seperator)
                 .Select(s => s.Trim())
                 .Where(n => !string.IsNullOrEmpty(n))
                 .ToArray() ?? new string[] { };

--- a/src/NSwagStudio/Views/CodeGenerators/SwaggerToCSharpClientGeneratorView.xaml
+++ b/src/NSwagStudio/Views/CodeGenerators/SwaggerToCSharpClientGeneratorView.xaml
@@ -206,7 +206,7 @@
 
                             <StackPanel Visibility="{Binding Command.GenerateDtoTypes, Converter={StaticResource VisibilityConverter}}">
                                 <TextBlock Text="Excluded Type Names (comma separated, must be defined in another namespace)." FontWeight="Bold" Margin="0,0,0,6" />
-                                <TextBox Text="{Binding Command.ExcludedTypeNames, Mode=TwoWay, Converter={StaticResource StringArrayConverter}}" 
+                                <TextBox Text="{Binding Command.ExcludedTypeNames, Mode=TwoWay, Converter={StaticResource StringArrayConverter}, ConverterParameter=','}" 
                                          ToolTip="ExcludedTypeNames" Margin="0,0,0,12" />
 
                                 <TextBlock Text="DTO class/enum access modifier" FontWeight="Bold" Margin="0,0,0,6" />


### PR DESCRIPTION
I introduced the idea of an optional separator that can be provided as a `ConverterParameter`.

I defaulted it to new line as I wasn't sure how many usages of this required updating and didn't want to blow this out into a huge change.

I was also unable to run it correctly on my machine due to missing dependencies, etc.

Hope this helps.

Output:

<img width="251" alt="image" src="https://user-images.githubusercontent.com/3029322/31977637-479b52ba-b99a-11e7-8bf4-3e94b9a03488.png">
