### PR TITLE
Recognize use of Microsoft.AspNetCore.Mvc.FromFormAttribute

### DIFF
--- a/src/NSwag.SwaggerGeneration.AspNetCore.Tests/AspNetCoreToSwaggerGenerationTests.cs
+++ b/src/NSwag.SwaggerGeneration.AspNetCore.Tests/AspNetCoreToSwaggerGenerationTests.cs
@@ -459,8 +459,6 @@ namespace NSwag.SwaggerGeneration.AspNetCore.Tests
             Assert.True(parameter.IsRequired);
         }
 
-
-
         [Fact]
         public async Task FormFileParametersAreDiscovered()
         {
@@ -724,7 +722,6 @@ namespace NSwag.SwaggerGeneration.AspNetCore.Tests
         {
             public BindingSource BindingSource => BindingSource.ModelBinding;
         }
-
 
         public class ReDocCodeSampleAttribute : SwaggerOperationProcessorAttribute
         {

--- a/src/NSwag.SwaggerGeneration.AspNetCore.Tests/AspNetCoreToSwaggerGenerationTests.cs
+++ b/src/NSwag.SwaggerGeneration.AspNetCore.Tests/AspNetCoreToSwaggerGenerationTests.cs
@@ -442,6 +442,26 @@ namespace NSwag.SwaggerGeneration.AspNetCore.Tests
         }
 
         [Fact]
+        public async Task FromFormParametersAreDiscovered()
+        {
+            //// Arrange
+            var generator = new AspNetCoreToSwaggerGenerator(new AspNetCoreToSwaggerGeneratorSettings());
+            var apiDescriptions = GetApiDescriptionGroups(typeof(ControllerWithParameters));
+
+            //// Act
+            var document = await generator.GenerateAsync(apiDescriptions);
+
+            //// Assert
+            var operation = Assert.Single(document.Operations, o => o.Path == "/" + nameof(ControllerWithParameters.FromFormParameter)).Operation;
+            var parameter = Assert.Single(operation.Parameters);
+            Assert.Equal(SwaggerParameterKind.FormData, parameter.Kind);
+            Assert.Equal("parameter1", parameter.Name);
+            Assert.True(parameter.IsRequired);
+        }
+
+
+
+        [Fact]
         public async Task FormFileParametersAreDiscovered()
         {
             //// Arrange
@@ -653,6 +673,9 @@ namespace NSwag.SwaggerGeneration.AspNetCore.Tests
 
             [HttpPost(nameof(FromBodyParameter))]
             public IActionResult FromBodyParameter([FromBody] TestModel model) => null;
+
+            [HttpPost(nameof(FromFormParameter))]
+            public IActionResult FromFormParameter([FromForm] string parameter1) => null;
 
             [HttpPost(nameof(FileParameter))]
             public IActionResult FileParameter(IFormFileCollection formFiles) => null;

--- a/src/NSwag.SwaggerGeneration.AspNetCore/Processors/OperationParameterProcessor.cs
+++ b/src/NSwag.SwaggerGeneration.AspNetCore/Processors/OperationParameterProcessor.cs
@@ -110,6 +110,13 @@ namespace NSwag.SwaggerGeneration.AspNetCore.Processors
                 }
                 else if (apiParameter.Source == BindingSource.Body)
                     await AddBodyParameterAsync(context, extendedApiParameter).ConfigureAwait(false);
+                else if (apiParameter.Source == BindingSource.Form)
+                {
+                    var operationParameter = await CreatePrimitiveParameterAsync(context, extendedApiParameter).ConfigureAwait(false);
+                    operationParameter.Kind = SwaggerParameterKind.FormData;
+
+                    context.OperationDescription.Operation.Parameters.Add(operationParameter);
+                }
                 else
                 {
                     if (await TryAddFileParameterAsync(context, extendedApiParameter).ConfigureAwait(false) == false)

--- a/src/NSwag.SwaggerGeneration.WebApi/Processors/OperationParameterProcessor.cs
+++ b/src/NSwag.SwaggerGeneration.WebApi/Processors/OperationParameterProcessor.cs
@@ -98,7 +98,8 @@ namespace NSwag.SwaggerGeneration.WebApi.Processors
                             operationParameter.Kind = SwaggerParameterKind.Header;
 
                             context.OperationDescription.Operation.Parameters.Add(operationParameter);
-                        } else if (fromFormAttribute != null)
+                        }
+                        else if (fromFormAttribute != null)
                         {
                             var operationParameter = await context.SwaggerGenerator.CreatePrimitiveParameterAsync(parameterName, parameter).ConfigureAwait(false);
                             operationParameter.Kind = SwaggerParameterKind.FormData;

--- a/src/NSwag.SwaggerGeneration.WebApi/Processors/OperationParameterProcessor.cs
+++ b/src/NSwag.SwaggerGeneration.WebApi/Processors/OperationParameterProcessor.cs
@@ -51,6 +51,7 @@ namespace NSwag.SwaggerGeneration.WebApi.Processors
 
                 dynamic fromRouteAttribute = attributes.TryGetIfAssignableTo("Microsoft.AspNetCore.Mvc.FromRouteAttribute");
                 dynamic fromHeaderAttribute = attributes.TryGetIfAssignableTo("Microsoft.AspNetCore.Mvc.FromHeaderAttribute");
+                dynamic fromFormAttribute = attributes.TryGetIfAssignableTo("Microsoft.AspNetCore.Mvc.FromFormAttribute");
                 var fromBodyAttribute = attributes.TryGetIfAssignableTo("FromBodyAttribute", TypeNameStyle.Name);
                 var fromUriAttribute = attributes.TryGetIfAssignableTo("FromUriAttribute", TypeNameStyle.Name) ??
                                        attributes.TryGetIfAssignableTo("FromQueryAttribute", TypeNameStyle.Name);
@@ -95,6 +96,13 @@ namespace NSwag.SwaggerGeneration.WebApi.Processors
 
                             var operationParameter = await context.SwaggerGenerator.CreatePrimitiveParameterAsync(parameterName, parameter).ConfigureAwait(false);
                             operationParameter.Kind = SwaggerParameterKind.Header;
+
+                            context.OperationDescription.Operation.Parameters.Add(operationParameter);
+                        } else if (fromFormAttribute != null)
+                        {
+                            var operationParameter = await context.SwaggerGenerator.CreatePrimitiveParameterAsync(parameterName, parameter).ConfigureAwait(false);
+                            operationParameter.Kind = SwaggerParameterKind.FormData;
+                            operationParameter.IsRequired = true;
 
                             context.OperationDescription.Operation.Parameters.Add(operationParameter);
                         }

--- a/src/NSwag.SwaggerGeneration.WebApi/Processors/OperationParameterProcessor.cs
+++ b/src/NSwag.SwaggerGeneration.WebApi/Processors/OperationParameterProcessor.cs
@@ -52,6 +52,7 @@ namespace NSwag.SwaggerGeneration.WebApi.Processors
                 dynamic fromRouteAttribute = attributes.TryGetIfAssignableTo("Microsoft.AspNetCore.Mvc.FromRouteAttribute");
                 dynamic fromHeaderAttribute = attributes.TryGetIfAssignableTo("Microsoft.AspNetCore.Mvc.FromHeaderAttribute");
                 dynamic fromFormAttribute = attributes.TryGetIfAssignableTo("Microsoft.AspNetCore.Mvc.FromFormAttribute");
+
                 var fromBodyAttribute = attributes.TryGetIfAssignableTo("FromBodyAttribute", TypeNameStyle.Name);
                 var fromUriAttribute = attributes.TryGetIfAssignableTo("FromUriAttribute", TypeNameStyle.Name) ??
                                        attributes.TryGetIfAssignableTo("FromQueryAttribute", TypeNameStyle.Name);

--- a/src/NSwag.SwaggerGeneration.WebApi/Processors/OperationParameterProcessor.cs
+++ b/src/NSwag.SwaggerGeneration.WebApi/Processors/OperationParameterProcessor.cs
@@ -103,7 +103,6 @@ namespace NSwag.SwaggerGeneration.WebApi.Processors
                         {
                             var operationParameter = await context.SwaggerGenerator.CreatePrimitiveParameterAsync(parameterName, parameter).ConfigureAwait(false);
                             operationParameter.Kind = SwaggerParameterKind.FormData;
-                            operationParameter.IsRequired = true;
 
                             context.OperationDescription.Operation.Parameters.Add(operationParameter);
                         }


### PR DESCRIPTION
With AspNetCore, you can use the attribute FromForm.
In the current version, that attribute is not recognize, so query as perform as "Query" type.

I've write test for AspNetCoreToSwaggerGeneration, but wasn't able to test it for real.
I've tested the WebApiToSwaggerGenerator, but didn't find any test testing that kind of thing.