### PR TITLE
Move npm to engines in packages.json

### DIFF
--- a/src/NSwag.Npm/package.json
+++ b/src/NSwag.Npm/package.json
@@ -18,7 +18,7 @@
   "bugs": {
     "url": "https://github.com/NSwag/NSwag/issues"
   },
-  "peerDependencies": {
+  "engines": {
     "npm": ">=3.10.8"
   },
   "description": "The Swagger API toolchain for .NET, Web API and TypeScript.",


### PR DESCRIPTION
In `package.json`, `npm` should be in `engines`. If it's in `peerDependencies` a warning is displayed if npm isn't installed locally.