### PR TITLE
Expand environment variables when using configuration file

### DIFF
--- a/src/NSwag.Commands/NSwagDocument.cs
+++ b/src/NSwag.Commands/NSwagDocument.cs
@@ -170,7 +170,11 @@ namespace NSwag.Commands
         /// <returns>The absolute path.</returns>
         protected override string ConvertToAbsolutePath(string pathToConvert)
         {
-            if (!string.IsNullOrEmpty(pathToConvert) && !System.IO.Path.IsPathRooted(pathToConvert))
+            if (string.IsNullOrEmpty(pathToConvert))
+                return pathToConvert;
+
+            pathToConvert = Environment.ExpandEnvironmentVariables(pathToConvert);
+            if (!System.IO.Path.IsPathRooted(pathToConvert))
                 return PathUtilities.MakeAbsolutePath(pathToConvert, GetDocumentDirectory());
             return pathToConvert;
         }
@@ -220,7 +224,7 @@ namespace NSwag.Commands
             processStart.CreateNoWindow = true;
 
             var process = Process.Start(processStart);
-            var output = await process.StandardOutput.ReadToEndAsync() + 
+            var output = await process.StandardOutput.ReadToEndAsync() +
                 "\n\n" + await process.StandardError.ReadToEndAsync();
 
             if (process.ExitCode != 0)


### PR DESCRIPTION
In my .NET Core 2.0 project I'm using EntityFrameworkCore, so I have to specify additional reference paths. This was already solved in https://github.com/RSuter/NSwag/issues/1004#issuecomment-337937640.

However, this doesn't work when using a config file. In my `.nswag` file I have added the paths like this:
```json
"referencePaths": [
  "C:/Program Files/dotnet/store/x64/netcoreapp2.0",
  "%USERPROFILE%/.nuget/packages"
]
```
Unfortunately, the second path isn't expanded but prefixed with the path to the `.nswag` file (because it's not rooted), i.e. it will be "fixed" to `c:\some path\%USERPROFILE%\.nuget\packages`.

This PR ensures that environment variables are expanded first before trying to make the path absolute.

/cc @roeb