### PR TITLE
Separate Logic Between Required and Optional Headers for Null Checking and Throwing Exceptions

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -152,7 +152,7 @@ urlBuilder_.Append("{{ parameter.Name }}=").Append(System.Uri.EscapeDataString({
 {%             else -%}
                 request_.Headers.TryAddWithoutValidation("{{ parameter.Name }}", ConvertToString({{ parameter.VariableName }}, System.Globalization.CultureInfo.InvariantCulture));
 {%             endif -%}
-{%         elseif parameter.IsOptional -%}
+{%         else -%}
                 if ({{ parameter.VariableName }} != null)
 {%             if parameter.IsStringArray -%}
                     request_.Headers.TryAddWithoutValidation("{{ parameter.Name }}", {{ parameter.VariableName }});

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -144,12 +144,21 @@ urlBuilder_.Append("{{ parameter.Name }}=").Append(System.Uri.EscapeDataString({
 {%     endif -%}
             {
 {%     for parameter in operation.HeaderParameters -%}
-{%         if parameter.IsStringArray -%}
-                if ({{ parameter.VariableName }} != null && {{ parameter.VariableName }}.Length != 0}})
-                    request_.Headers.TryAddWithoutValidation("{{ parameter.Name }}", {{ parameter.VariableName }});
-{%         else -%}
+{%         if parameter.IsRequired -%}
+                if ({{ parameter.VariableName }} == null)
+                    throw new System.ArgumentNullException("{{ parameter.VariableName }}");
+{%             if parameter.IsStringArray -%}
+                request_.Headers.TryAddWithoutValidation("{{ parameter.Name }}", {{ parameter.VariableName }});
+{%             else -%}
+                request_.Headers.TryAddWithoutValidation("{{ parameter.Name }}", ConvertToString({{ parameter.VariableName }}, System.Globalization.CultureInfo.InvariantCulture));
+{%             endif -%}
+{%         elseif parameter.IsOptional -%}
                 if ({{ parameter.VariableName }} != null)
+{%             if parameter.IsStringArray -%}
+                    request_.Headers.TryAddWithoutValidation("{{ parameter.Name }}", {{ parameter.VariableName }});
+{%             else -%}
                     request_.Headers.TryAddWithoutValidation("{{ parameter.Name }}", ConvertToString({{ parameter.VariableName }}, System.Globalization.CultureInfo.InvariantCulture));
+{%             endif -%}
 {%         endif -%}
 {%     endfor -%}
 {%     if operation.HasContent -%}


### PR DESCRIPTION
Enhancement for Issue: https://github.com/RSuter/NSwag/issues/1125 : 

We should differentiate between required and optional headers instead of all headers in general. In the case that it is a required header, we should check if the value is null, and if so throw an exception, but when the header is optional, we just need to check if the value is null or not. If it is null then we don't need to add the header nor throw an exception.


This also includes a bug fix for PR https://github.com/RSuter/NSwag/pull/1126. The bug is at the end of line 148 where we have an extra "}}" at the end of the if statement with no matching "{{".