### PR TITLE
Added explicit conversion from byte[] to Base64 string

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -295,9 +295,9 @@ urlBuilder_.Append("{{ parameter.Name }}=").Append(System.Uri.EscapeDataString({
                 }
             }
         }
-        else if (value is byte[] bytes)
+        else if (value is byte[])
         {
-            return System.Convert.ToBase64String(bytes);
+            return System.Convert.ToBase64String((byte[])value);
         }
         else if (value.GetType().IsArray)
         {

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -295,6 +295,10 @@ urlBuilder_.Append("{{ parameter.Name }}=").Append(System.Uri.EscapeDataString({
                 }
             }
         }
+        else if (value is byte[] bytes)
+        {
+            return System.Convert.ToBase64String(bytes);
+        }
         else if (value.GetType().IsArray)
         {
             var array = System.Linq.Enumerable.OfType<object>((System.Array) value);

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -297,7 +297,7 @@ urlBuilder_.Append("{{ parameter.Name }}=").Append(System.Uri.EscapeDataString({
         }
         else if (value is byte[])
         {
-            return System.Convert.ToBase64String((byte[])value);
+            return System.Convert.ToBase64String((byte[]) value);
         }
         else if (value.GetType().IsArray)
         {


### PR DESCRIPTION
I have a model which is used both in the backend and the frontend, which has a `byte[]` property. I'm using [Swashbuckle](https://github.com/domaindrivendev/Swashbuckle.AspNetCore) to create the swagger json file and then using NSwag in my CI server to create the clients and publishing them to my company's nuget feed. Fortunately, Asp Net Core binding takes the a Base64 string and automatically decodes it to the `byte[]`. However, the clients generated by NSwag transform each byte to a string and then concatenates them, which renders the binding more complex. 

I found that the simple adding
```Csharp
else if (value is byte[] bytes)
{
    return System.Convert.ToBase64String(bytes);
}
``` 
To the ConvertToString in the liquid template fixes this, however I'm not sure if it a behavior that everybody would want, so I would understand if this PR is not accepted. If that happens, could you give some directions in how to personalize this kind of things?

Cheers