### PR TITLE
Do not call UpdateJsonSerializerSettings if method does not exists.

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -36,7 +36,9 @@
 {% if SerializeTypeInformation -%}
             settings.TypeNameHandling = Newtonsoft.Json.TypeNameHandling.Auto;
 {% endif -%}
+{% if GenerateUpdateJsonSerializerSettingsMethod -%}
             UpdateJsonSerializerSettings(settings);
+{% endif -%}
             return settings;
         });
     }


### PR DESCRIPTION
When the code generation preference `generateUpdateJsonSerializerSettingsMethod` is set to false we should not make call to `UpdateJsonSerializerSettings`

Unable to compile client because of the following error

```
Severity	Code	Description	Project	File	Line	Suppression State
Error	CS0103	The name 'UpdateJsonSerializerSettings' does not exist in the current context
```