### PR TITLE
Move command entry points to NSwag.Commands

### DIFF
--- a/src/NSwag.AspNetCore.Launcher/Program.cs
+++ b/src/NSwag.AspNetCore.Launcher/Program.cs
@@ -7,9 +7,12 @@ namespace NSwag.AspNetCore.Launcher
 {
     internal class Program
     {
-        private const string EntryPointType = "NSwag.SwaggerGeneration.AspNetCore.AspNetCoreToSwaggerGeneratorCommandEntryPoint";
-        private static readonly AssemblyName AspNetCoreSwaggerGenerationAssembly = new AssemblyName("NSwag.SwaggerGeneration.AspNetCore");
+        // Used to load NSwag.Commands into a process running with the app's dependency context
+        private const string EntryPointType = "NSwag.Commands.AspNetCoreToSwaggerGeneratorCommandEntryPoint";
+        private static readonly AssemblyName CommandsAssemblyName = new AssemblyName("NSwag.Commands");
+
         private static readonly Version NSwagVersion = typeof(Program).GetTypeInfo().Assembly.GetName().Version;
+
         // List of assemblies and versions referenced by NSwag.SwaggerGeneration.AspNetCore. This represents the minimum versions
         // required to successfully run the tool.
         private static readonly Dictionary<string, AssemblyLoadInfo> NSwagReferencedAssemblies = new Dictionary<string, AssemblyLoadInfo>(StringComparer.OrdinalIgnoreCase)
@@ -43,6 +46,7 @@ namespace NSwag.AspNetCore.Launcher
             ["Newtonsoft.Json"] = new AssemblyLoadInfo(new Version(9, 0, 0)),
             ["NJsonSchema"] = new AssemblyLoadInfo(new Version(9, 7, 7)),
             ["NSwag.AssemblyLoader"] = new AssemblyLoadInfo(NSwagVersion),
+            ["NSwag.Commands"] = new AssemblyLoadInfo(NSwagVersion),
             ["NSwag.Core"] = new AssemblyLoadInfo(NSwagVersion),
             ["NSwag.SwaggerGeneration.AspNetCore"] = new AssemblyLoadInfo(NSwagVersion),
             ["NSwag.SwaggerGeneration"] = new AssemblyLoadInfo(NSwagVersion),
@@ -87,7 +91,7 @@ namespace NSwag.AspNetCore.Launcher
                     throw new InvalidOperationException($"Referenced assembly '{assemblyName}' was not found in {toolsDirectory}.");
                 return context.LoadFromAssemblyPath(assemblyLocation);
             };
-            var assembly = loadContext.LoadFromAssemblyName(AspNetCoreSwaggerGenerationAssembly);
+            var assembly = loadContext.LoadFromAssemblyName(CommandsAssemblyName);
 #else
             AppDomain.CurrentDomain.AssemblyResolve += (source, eventArgs) =>
             {
@@ -106,7 +110,7 @@ namespace NSwag.AspNetCore.Launcher
                 return Assembly.LoadFile(assemblyLocation);
             };
 
-            var assembly = Assembly.Load(AspNetCoreSwaggerGenerationAssembly);
+            var assembly = Assembly.Load(CommandsAssemblyName);
 #endif
 
             var type = assembly.GetType(EntryPointType, throwOnError: true);

--- a/src/NSwag.Commands/Commands/AspNetCoreToSwaggerGeneratorCommandEntryPoint.cs
+++ b/src/NSwag.Commands/Commands/AspNetCoreToSwaggerGeneratorCommandEntryPoint.cs
@@ -8,11 +8,12 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
+using NSwag.SwaggerGeneration.AspNetCore;
 using NSwag.SwaggerGeneration.Processors;
 
-namespace NSwag.SwaggerGeneration.AspNetCore
+namespace NSwag.Commands
 {
-    /// <summary>An entry point for the aspnetcore2swagger command.</summary>
+    /// <summary>In-process entry point for the aspnetcore2swagger command.</summary>
     internal class AspNetCoreToSwaggerGeneratorCommandEntryPoint
     {
         public static void Process(string settingsData)

--- a/src/NSwag.Commands/Commands/AspNetCoreToSwaggerGeneratorCommandSettings.cs
+++ b/src/NSwag.Commands/Commands/AspNetCoreToSwaggerGeneratorCommandSettings.cs
@@ -6,7 +6,9 @@
 // <author>Rico Suter, mail@rsuter.com</author>
 //-----------------------------------------------------------------------
 
-namespace NSwag.SwaggerGeneration.AspNetCore
+using NSwag.SwaggerGeneration.AspNetCore;
+
+namespace NSwag.Commands
 {
     /// <summary>Settings for the AspNetCoreToSwaggerGeneratorCommand and AspNetCoreToSwaggerGeneratorCommandEntryPoint.</summary>
     public class AspNetCoreToSwaggerGeneratorCommandSettings : AspNetCoreToSwaggerGeneratorSettings

--- a/src/NSwag.Min.sln
+++ b/src/NSwag.Min.sln
@@ -36,8 +36,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NSwag.Core.Yaml", "NSwag.Co
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NSwag.SwaggerGeneration.AspNetCore", "NSwag.SwaggerGeneration.AspNetCore\NSwag.SwaggerGeneration.AspNetCore.csproj", "{51740C29-AF4F-40AD-BFDE-09E6F8C873D2}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NSwag.AssemblyLoader", "NSwag.AssemblyLoader\NSwag.AssemblyLoader.csproj", "{E6A8E5FD-4DD2-4D44-B843-F3975631423C}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NSwag.Core.Tests", "NSwag.Core.Tests\NSwag.Core.Tests.csproj", "{6AB4FD70-2CCF-4876-A193-B5FD6B32C39A}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "09 Samples", "09 Samples", "{A0338E8D-A4A3-4380-9FF7-1D0BDC260E31}"
@@ -275,24 +273,6 @@ Global
 		{51740C29-AF4F-40AD-BFDE-09E6F8C873D2}.ReleaseTypeScriptStrict|x64.Build.0 = Release|Any CPU
 		{51740C29-AF4F-40AD-BFDE-09E6F8C873D2}.ReleaseTypeScriptStrict|x86.ActiveCfg = Release|Any CPU
 		{51740C29-AF4F-40AD-BFDE-09E6F8C873D2}.ReleaseTypeScriptStrict|x86.Build.0 = Release|Any CPU
-		{E6A8E5FD-4DD2-4D44-B843-F3975631423C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E6A8E5FD-4DD2-4D44-B843-F3975631423C}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E6A8E5FD-4DD2-4D44-B843-F3975631423C}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{E6A8E5FD-4DD2-4D44-B843-F3975631423C}.Debug|x64.Build.0 = Debug|Any CPU
-		{E6A8E5FD-4DD2-4D44-B843-F3975631423C}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{E6A8E5FD-4DD2-4D44-B843-F3975631423C}.Debug|x86.Build.0 = Debug|Any CPU
-		{E6A8E5FD-4DD2-4D44-B843-F3975631423C}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{E6A8E5FD-4DD2-4D44-B843-F3975631423C}.Release|Any CPU.Build.0 = Release|Any CPU
-		{E6A8E5FD-4DD2-4D44-B843-F3975631423C}.Release|x64.ActiveCfg = Release|Any CPU
-		{E6A8E5FD-4DD2-4D44-B843-F3975631423C}.Release|x64.Build.0 = Release|Any CPU
-		{E6A8E5FD-4DD2-4D44-B843-F3975631423C}.Release|x86.ActiveCfg = Release|Any CPU
-		{E6A8E5FD-4DD2-4D44-B843-F3975631423C}.Release|x86.Build.0 = Release|Any CPU
-		{E6A8E5FD-4DD2-4D44-B843-F3975631423C}.ReleaseTypeScriptStrict|Any CPU.ActiveCfg = Release|Any CPU
-		{E6A8E5FD-4DD2-4D44-B843-F3975631423C}.ReleaseTypeScriptStrict|Any CPU.Build.0 = Release|Any CPU
-		{E6A8E5FD-4DD2-4D44-B843-F3975631423C}.ReleaseTypeScriptStrict|x64.ActiveCfg = Release|Any CPU
-		{E6A8E5FD-4DD2-4D44-B843-F3975631423C}.ReleaseTypeScriptStrict|x64.Build.0 = Release|Any CPU
-		{E6A8E5FD-4DD2-4D44-B843-F3975631423C}.ReleaseTypeScriptStrict|x86.ActiveCfg = Release|Any CPU
-		{E6A8E5FD-4DD2-4D44-B843-F3975631423C}.ReleaseTypeScriptStrict|x86.Build.0 = Release|Any CPU
 		{6AB4FD70-2CCF-4876-A193-B5FD6B32C39A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6AB4FD70-2CCF-4876-A193-B5FD6B32C39A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6AB4FD70-2CCF-4876-A193-B5FD6B32C39A}.Debug|x64.ActiveCfg = Debug|Any CPU

--- a/src/NSwag.SwaggerGeneration.AspNetCore/NSwag.SwaggerGeneration.AspNetCore.csproj
+++ b/src/NSwag.SwaggerGeneration.AspNetCore/NSwag.SwaggerGeneration.AspNetCore.csproj
@@ -30,7 +30,6 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\NSwag.AssemblyLoader\NSwag.AssemblyLoader.csproj" />
     <ProjectReference Include="..\NSwag.SwaggerGeneration\NSwag.SwaggerGeneration.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This removes the assembly loader from the reference graph of assemblies
like NSwag.SwaggerGeneration.AspNetCore