### PR TITLE
Fix TS request url generation bug

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript/Templates/Client.RequestUrl.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/Client.RequestUrl.liquid
@@ -17,7 +17,7 @@ url_ = url_.replace("{{ "{" }}{{ parameter.Name }}}", encodeURIComponent("" + {{
 {%     endif -%}
 {%     if parameter.IsOptional -%}
 else
-    url_ = url_.replace("/{{{ parameter.Name }}}", ""); 
+    url_ = url_.replace("/{{ parameter.Name }}", ""); 
 {%     endif -%}
 {% endfor -%}
 {% for parameter in operation.QueryParameters -%}


### PR DESCRIPTION
Hello everyone! :blush: 

this PR attempts to fix code generation for optional arguments in TypeScript (Issue #1275).

I am neither familiar with the project nor Liquid. 
I just quickly read into liquid and NSwag internals and the triple '{' seem to be a typo.
Either way, they cause Liquid to re-evaluate the return value of reading `parameter.Name`, which is `null`.

Hoping that this will be a helpful contribution, the project seems to be just what I was looking for.
Thanks!