### PR TITLE
CSharp generator - check for null response content.

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ProcessResponse.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ProcessResponse.liquid
@@ -1,16 +1,16 @@
 {% if response.HasType -%}
 {%     if response.IsFile -%}
 {%         if response.IsSuccess -%}
-var responseStream_ = await response_.Content.ReadAsStreamAsync().ConfigureAwait(false);
+var responseStream_ = response_.Content == null ? null : await response_.Content.ReadAsStreamAsync().ConfigureAwait(false);
 var fileResponse_ = new FileResponse((int)response_.StatusCode, headers_, responseStream_, {% if InjectHttpClient %}null{% else %}client_{% endif %}, response_); 
 client_ = null; response_ = null; // response and client are disposed by FileResponse
 return fileResponse_;
 {%         else -%}
-var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
+var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
 throw new {{ ExceptionClass }}("{{ response.ExceptionDescription }}", (int)response_.StatusCode, responseData_, headers_, null);
 {%         endif -%}
 {%     else -%}
-var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
+var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
 var result_ = default({{ response.Type }}); 
 try
 {
@@ -59,6 +59,6 @@ return;
 {%         endif -%}
 {%     endif -%}
 {% else -%}
-var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
+var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
 throw new {{ ExceptionClass }}("{{ response.ExceptionDescription }}", (int)response_.StatusCode, responseData_, headers_, null);
 {% endif -%}

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ProcessResponse.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ProcessResponse.liquid
@@ -1,7 +1,7 @@
 {% if response.HasType -%}
 {%     if response.IsFile -%}
 {%         if response.IsSuccess -%}
-var responseStream_ = response_.Content == null ? null : await response_.Content.ReadAsStreamAsync().ConfigureAwait(false);
+var responseStream_ = response_.Content == null ? System.IO.Stream.Null : await response_.Content.ReadAsStreamAsync().ConfigureAwait(false);
 var fileResponse_ = new FileResponse((int)response_.StatusCode, headers_, responseStream_, {% if InjectHttpClient %}null{% else %}client_{% endif %}, response_); 
 client_ = null; response_ = null; // response and client are disposed by FileResponse
 return fileResponse_;

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -241,14 +241,14 @@ urlBuilder_.Append("{{ parameter.Name }}=").Append(System.Uri.EscapeDataString({
                     }
 {%         else -%}
 {%             if operation.HasSuccessResponse -%}
-                    var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
+                    var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
                     throw new {{ ExceptionClass }}("{{ operation.DefaultResponse.ExceptionDescription }}", (int)response_.StatusCode, responseData_, headers_, null);
 {%             endif -%}
 {%         endif -%}
 {%     else -%}
                     if (status_ != "200" && status_ != "204")
                     {
-                        var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
+                        var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
                         throw new {{ ExceptionClass }}("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", (int)response_.StatusCode, responseData_, headers_, null);
                     }
 {%     endif -%}


### PR DESCRIPTION
Checks if the response._Content is null before attempting to read the stream. Fixes #1291