### PR TITLE
Fixes null ref exception when generating 3.0 clients with request bodies

### DIFF
--- a/src/NSwag.Core/SwaggerOperation.cs
+++ b/src/NSwag.Core/SwaggerOperation.cs
@@ -255,7 +255,7 @@ namespace NSwag
         private void UpdateBodyParameter(SwaggerParameter parameter)
         {
             parameter.Kind = SwaggerParameterKind.Body;
-            parameter.Name = RequestBody.Name;
+            parameter.Name = RequestBody.ActualName;
             parameter.Description = RequestBody.Description;
             parameter.IsRequired = RequestBody.IsRequired;
             parameter.Example = RequestBody.Content.FirstOrDefault().Value?.Example;


### PR DESCRIPTION
Fixes issue where request bodies cause null ref exceptions when generating client because ActualName instead of Name should be used when creating the parameter name since this provides a fallback to 'body' in the event that Name is null.