### PR TITLE
NSwagExe_Core20 broken in 11.7.4

### DIFF
--- a/src/NSwag.MSBuild/NSwag.MSBuild.props
+++ b/src/NSwag.MSBuild/NSwag.MSBuild.props
@@ -6,12 +6,12 @@
     <NSwagExe_Core10>dotnet "$(MSBuildThisFileDirectory)NetCore10/dotnet-nswag.dll"</NSwagExe_Core10>
     <NSwagExe_Core11>dotnet "$(MSBuildThisFileDirectory)NetCore11/dotnet-nswag.dll"</NSwagExe_Core11>
     <NSwagExe_Core20>dotnet "$(MSBuildThisFileDirectory)NetCore20/dotnet-nswag.dll"</NSwagExe_Core20>
-    <NSwagExe_Core20>dotnet "$(MSBuildThisFileDirectory)NetCore21/dotnet-nswag.dll"</NSwagExe_Core20>
+    <NSwagExe_Core21>dotnet "$(MSBuildThisFileDirectory)NetCore21/dotnet-nswag.dll"</NSwagExe_Core21>
 
     <NSwagDir>$(MSBuildThisFileDirectory)Win/</NSwagDir>
     <NSwagDir_Core10>$(MSBuildThisFileDirectory)NetCore10/</NSwagDir_Core10>
     <NSwagDir_Core11>$(MSBuildThisFileDirectory)NetCore11/</NSwagDir_Core11>
     <NSwagDir_Core20>$(MSBuildThisFileDirectory)NetCore20/</NSwagDir_Core20>
-    <NSwagDir_Core20>$(MSBuildThisFileDirectory)NetCore21/</NSwagDir_Core20>
+    <NSwagDir_Core21>$(MSBuildThisFileDirectory)NetCore21/</NSwagDir_Core21>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
In 11.7.4 `NSwagExe_Core20` is broken, because it gets overwritten with the value for `NSwagExe_Core21`. I suggest to release a hotfix as soon as possible.