### PR TITLE
Improve .NET Core 2.1 sample

### DIFF
--- a/src/NSwag.Sample.NETCore21/Controllers/PetController.cs
+++ b/src/NSwag.Sample.NETCore21/Controllers/PetController.cs
@@ -20,6 +20,7 @@ namespace NSwag.Sample
         [HttpPost]
         [Consumes("application/json")]
         [Produces("application/json")]
+        [ProducesResponseType(typeof(void), (int)HttpStatusCode.NoContent)]
         [ProducesResponseType(typeof(SerializableError), (int)HttpStatusCode.BadRequest)]
         public async Task<IActionResult> AddPet([FromBody] Pet pet)
         {
@@ -31,6 +32,7 @@ namespace NSwag.Sample
         [HttpPut]
         [Consumes("application/json")]
         [Produces("application/json")]
+        [ProducesResponseType(typeof(void), (int)HttpStatusCode.NoContent)]
         [ProducesResponseType(typeof(SerializableError), (int)HttpStatusCode.BadRequest)]
         public async Task<IActionResult> EditPet([FromBody] Pet pet)
         {
@@ -44,9 +46,9 @@ namespace NSwag.Sample
         }
 
         // 'status' is intended to be an optional query string parameter
+        // Sample with ActionResult<T> auto-detection
         [HttpGet("findByStatus")]
         [Produces("application/json")]
-        [ProducesResponseType(typeof(SerializableError), (int)HttpStatusCode.BadRequest)]
         public async Task<ActionResult<IEnumerable<Pet>>> FindByStatus(string[] status)
         {
             await Task.Delay(0);
@@ -57,6 +59,7 @@ namespace NSwag.Sample
         // to represent an action with a required query parameter.
         [HttpGet("findByCategory")]
         [Produces("application/json")]
+        [ProducesResponseType(typeof(IEnumerable<Pet>), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(SerializableError), (int)HttpStatusCode.BadRequest)]
         public async Task<ActionResult<IEnumerable<Pet>>> FindByCategory([BindRequired] string category)
         {
@@ -66,6 +69,7 @@ namespace NSwag.Sample
 
         [HttpGet("{petId}", Name = "FindPetById")]
         [Produces("application/json")]
+        [ProducesResponseType(typeof(Pet), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(SerializableError), (int)HttpStatusCode.BadRequest)]
         [ProducesResponseType((int)HttpStatusCode.NotFound)]
         public async Task<ActionResult<Pet>> FindById(int petId)
@@ -87,6 +91,7 @@ namespace NSwag.Sample
         [HttpPost("{petId}")]
         [Consumes("application/www-form-url-encoded")]
         [Produces("application/json")]
+        [ProducesResponseType(typeof(void), (int)HttpStatusCode.NoContent)]
         [ProducesResponseType(typeof(SerializableError), (int)HttpStatusCode.BadRequest)]
         [ProducesResponseType((int)HttpStatusCode.NotFound)]
         public async Task<IActionResult> EditPet(int petId, [FromForm] Pet pet)
@@ -102,6 +107,7 @@ namespace NSwag.Sample
 
         [HttpDelete("{petId}")]
         [Produces("application/json")]
+        [ProducesResponseType(typeof(void), (int)HttpStatusCode.NoContent)]
         [ProducesResponseType(typeof(SerializableError), (int)HttpStatusCode.BadRequest)]
         [ProducesResponseType((int)HttpStatusCode.NotFound)]
         public async Task<IActionResult> DeletePet(int petId)
@@ -118,6 +124,7 @@ namespace NSwag.Sample
         [HttpPost("{petId}/uploadImage")]
         [Consumes("multipart/form-data")]
         [Produces("application/json")]
+        [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(SerializableError), (int)HttpStatusCode.BadRequest)]
         [ProducesResponseType((int)HttpStatusCode.NotFound)]
         public async Task<ActionResult<ApiResponse>> UploadImage(int petId, IFormFile file)

--- a/src/NSwag.Sample.NETCore21/swagger.json
+++ b/src/NSwag.Sample.NETCore21/swagger.json
@@ -1,12 +1,11 @@
-﻿{
-  "x-generator": "NSwag v11.15.4.0 (NJsonSchema v9.10.31.0 (Newtonsoft.Json v10.0.0.0))",
+{
+  "x-generator": "NSwag v11.17.15.0 (NJsonSchema v9.10.53.0 (Newtonsoft.Json v10.0.0.0))",
   "swagger": "2.0",
   "info": {
-    "title": "Web API Swagger specification",
+    "title": "My Title",
     "version": "1.0.0"
   },
   "host": "localhost:44370",
-  "basePath": "",
   "schemes": [
     "https"
   ],
@@ -42,12 +41,15 @@
           }
         ],
         "responses": {
+          "204": {
+            "description": ""
+          },
           "400": {
+            "x-nullable": true,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
-            },
-            "x-nullable": true
+            }
           }
         }
       },
@@ -71,12 +73,15 @@
           }
         ],
         "responses": {
+          "204": {
+            "description": ""
+          },
           "400": {
+            "x-nullable": true,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
-            },
-            "x-nullable": true
+            }
           }
         }
       }
@@ -108,12 +113,15 @@
           }
         ],
         "responses": {
-          "400": {
+          "200": {
+            "x-nullable": true,
             "description": "",
             "schema": {
-              "$ref": "#/definitions/SerializableError"
-            },
-            "x-nullable": true
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Pet"
+              }
+            }
           }
         }
       }
@@ -134,12 +142,22 @@
           }
         ],
         "responses": {
+          "200": {
+            "x-nullable": true,
+            "description": "",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Pet"
+              }
+            }
+          },
           "400": {
+            "x-nullable": true,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
-            },
-            "x-nullable": true
+            }
           }
         }
       }
@@ -156,17 +174,24 @@
             "name": "petId",
             "in": "path",
             "required": true,
-            "x-nullable": false,
-            "format": "int32"
+            "format": "int32",
+            "x-nullable": false
           }
         ],
         "responses": {
+          "200": {
+            "x-nullable": true,
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          },
           "400": {
+            "x-nullable": true,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
-            },
-            "x-nullable": true
+            }
           },
           "404": {
             "description": ""
@@ -184,32 +209,32 @@
             "name": "petId",
             "in": "path",
             "required": true,
-            "x-nullable": false,
-            "format": "int32"
+            "format": "int32",
+            "x-nullable": false
           },
           {
             "type": "integer",
             "name": "Id",
             "in": "formData",
             "required": true,
-            "x-nullable": false,
-            "format": "int32"
+            "format": "int32",
+            "x-nullable": false
           },
           {
             "type": "integer",
             "name": "Age",
             "in": "formData",
             "required": true,
-            "x-nullable": false,
-            "format": "int32"
+            "format": "int32",
+            "x-nullable": false
           },
           {
             "type": "integer",
             "name": "Category.Id",
             "in": "formData",
             "required": true,
-            "x-nullable": false,
-            "format": "int32"
+            "format": "int32",
+            "x-nullable": false
           },
           {
             "type": "string",
@@ -237,8 +262,8 @@
             "name": "Images",
             "in": "formData",
             "required": true,
-            "x-nullable": true,
             "collectionFormat": "multi",
+            "x-nullable": true,
             "items": {
               "$ref": "#/definitions/Image"
             }
@@ -248,8 +273,8 @@
             "name": "Tags",
             "in": "formData",
             "required": true,
-            "x-nullable": true,
             "collectionFormat": "multi",
+            "x-nullable": true,
             "items": {
               "$ref": "#/definitions/Tag"
             }
@@ -263,12 +288,15 @@
           }
         ],
         "responses": {
+          "204": {
+            "description": ""
+          },
           "400": {
+            "x-nullable": true,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
-            },
-            "x-nullable": true
+            }
           },
           "404": {
             "description": ""
@@ -286,17 +314,20 @@
             "name": "petId",
             "in": "path",
             "required": true,
-            "x-nullable": false,
-            "format": "int32"
+            "format": "int32",
+            "x-nullable": false
           }
         ],
         "responses": {
+          "204": {
+            "description": ""
+          },
           "400": {
+            "x-nullable": true,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
-            },
-            "x-nullable": true
+            }
           },
           "404": {
             "description": ""
@@ -319,8 +350,8 @@
             "name": "petId",
             "in": "path",
             "required": true,
-            "x-nullable": false,
-            "format": "int32"
+            "format": "int32",
+            "x-nullable": false
           },
           {
             "type": "file",
@@ -331,12 +362,19 @@
           }
         ],
         "responses": {
+          "200": {
+            "x-nullable": true,
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ApiResponse"
+            }
+          },
           "400": {
+            "x-nullable": true,
             "description": "",
             "schema": {
               "$ref": "#/definitions/SerializableError"
-            },
-            "x-nullable": true
+            }
           },
           "404": {
             "description": ""
@@ -452,9 +490,25 @@
           "additionalProperties": {}
         }
       ]
+    },
+    "ApiResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "code"
+      ],
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      }
     }
-  },
-  "parameters": {},
-  "responses": {},
-  "securityDefinitions": {}
+  }
 }


### PR DESCRIPTION
Update sample so that 200 and 204 responses are included. 

@pranavkm @rynowak is it correct that the 200/204 responses have to be specified when other status codes are specified with the ProducesResponseTypeAttribute? Is there a reason why you didn't implement the sample controller as in this PR? Does the controller now look as intended?