### PR TITLE
Fix return type generation for nested Task<ActionResult<T>> types

### DIFF
--- a/src/NSwag.SwaggerGeneration/Processors/OperationResponseProcessorBase.cs
+++ b/src/NSwag.SwaggerGeneration/Processors/OperationResponseProcessorBase.cs
@@ -195,9 +195,7 @@ namespace NSwag.SwaggerGeneration.Processors
             var returnType = returnParameter.ParameterType;
             if (returnType == typeof(Task))
                 returnType = typeof(void);
-            else if (returnType.Name == "Task`1")
-                returnType = returnType.GenericTypeArguments[0];
-            else if (returnType.Name == "ActionResult`1")
+            while (returnType.Name == "Task`1" || returnType.Name == "ActionResult`1")
                 returnType = returnType.GenericTypeArguments[0];
 
             if (IsVoidResponse(returnType))


### PR DESCRIPTION
Currently an ASP.Net return type of Task<ActionResult<T>> will generate a TypeScript class of ActionResultOfT which doesn't match the response which is just a T, since it only removes the outermost generic type. This PR will keep peeling off Task<> and ActionResult<> wrappers until it finds an underlying type.