### PR TITLE
Add support for using swagger `operationId` property as route name in `RouteAttribute`s of generated controllers

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp.Tests/ControllerGenerationFormatTests.cs
+++ b/src/NSwag.CodeGeneration.CSharp.Tests/ControllerGenerationFormatTests.cs
@@ -145,6 +145,46 @@ namespace NSwag.CodeGeneration.CSharp.Tests
             Assert.IsTrue(code.Contains("Foo(string test, bool test2)"));
             Assert.IsTrue(code.Contains("Bar()"));
         }
+
+        [TestMethod]
+        public async Task When_controllerroutenamingstrategy_operationid_then_route_attribute_name_specified()
+        {
+            //// Arrange
+            var swaggerGen = new WebApiToSwaggerGenerator(new WebApiToSwaggerGeneratorSettings());
+            var document = await swaggerGen.GenerateForControllerAsync<TestController>();
+            var settings = new SwaggerToCSharpControllerGeneratorSettings
+            {
+                RouteNamingStrategy = CSharpControllerRouteNamingStrategy.OperationId
+            };
+
+            //// Act
+            var codeGen = new SwaggerToCSharpControllerGenerator(document, settings);
+            var code = codeGen.GenerateFile();
+
+            //// Assert
+            Assert.IsTrue(code.Contains("Route(\"Foo\", Name = \"Test_Foo\")"));
+            Assert.IsTrue(code.Contains("Route(\"Bar\", Name = \"Test_Bar\")"));
+        }
+
+        [TestMethod]
+        public async Task When_controllerroutenamingstrategy_none_then_route_attribute_name_not_specified()
+        {
+            //// Arrange
+            var swaggerGen = new WebApiToSwaggerGenerator(new WebApiToSwaggerGeneratorSettings());
+            var document = await swaggerGen.GenerateForControllerAsync<TestController>();
+            var settings = new SwaggerToCSharpControllerGeneratorSettings
+            {
+                RouteNamingStrategy = CSharpControllerRouteNamingStrategy.None
+            };
+
+            //// Act
+            var codeGen = new SwaggerToCSharpControllerGenerator(document, settings);
+            var code = codeGen.GenerateFile();
+
+            //// Assert
+            Assert.IsTrue(code.Contains("Route(\"Foo\")"));
+            Assert.IsTrue(code.Contains("Route(\"Bar\")"));
+        }
     }
 }
 

--- a/src/NSwag.CodeGeneration.CSharp/Models/CSharpControllerRouteNamingStrategy.cs
+++ b/src/NSwag.CodeGeneration.CSharp/Models/CSharpControllerRouteNamingStrategy.cs
@@ -1,14 +1,13 @@
 ﻿//-----------------------------------------------------------------------
 // <copyright file="CSharpControllerRouteNamingStrategy.cs" company="NSwag">
-//     Copyright (c) Sam Goldmann. All rights reserved.
+//     Copyright (c) Rico Suter. All rights reserved.
 // </copyright>
 // <license>https://github.com/NSwag/NSwag/blob/master/LICENSE.md</license>
-// <author>Sam Goldmann, sam.goldmann@gmail.com</author>
+// <author>Rico Suter, mail@rsuter.com</author>
 //-----------------------------------------------------------------------
 
 namespace NSwag.CodeGeneration.CSharp.Models
 {
-    
     /// <summary>The CSharp controller routing naming strategy enum.</summary>
     public enum CSharpControllerRouteNamingStrategy
     {

--- a/src/NSwag.CodeGeneration.CSharp/Models/CSharpControllerRouteNamingStrategy.cs
+++ b/src/NSwag.CodeGeneration.CSharp/Models/CSharpControllerRouteNamingStrategy.cs
@@ -1,0 +1,21 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="CSharpControllerRouteNamingStrategy.cs" company="NSwag">
+//     Copyright (c) Sam Goldmann. All rights reserved.
+// </copyright>
+// <license>https://github.com/NSwag/NSwag/blob/master/LICENSE.md</license>
+// <author>Sam Goldmann, sam.goldmann@gmail.com</author>
+//-----------------------------------------------------------------------
+
+namespace NSwag.CodeGeneration.CSharp.Models
+{
+    
+    /// <summary>The CSharp controller routing naming strategy enum.</summary>
+    public enum CSharpControllerRouteNamingStrategy
+    {
+        /// <summary>Disable route naming.</summary>
+        None,
+
+        /// <summary>Use the operationId as the route name, if available.</summary>
+        OperationId
+    }
+}

--- a/src/NSwag.CodeGeneration.CSharp/Models/CSharpOperationModel.cs
+++ b/src/NSwag.CodeGeneration.CSharp/Models/CSharpOperationModel.cs
@@ -169,6 +169,19 @@ namespace NSwag.CodeGeneration.CSharp.Models
             }
         }
 
+        /// <summary>Gets the route name for this operation.</summary>
+        public string RouteName
+        {
+            get
+            {
+                var settings = _settings as SwaggerToCSharpControllerGeneratorSettings;
+                if (settings != null)
+                    return settings.GetRouteName(_operation);
+
+                return null;
+            }
+        }
+
         /// <summary>Gets the name of the parameter variable.</summary>
         /// <param name="parameter">The parameter.</param>
         /// <param name="allParameters">All parameters.</param>

--- a/src/NSwag.CodeGeneration.CSharp/Models/CSharpOperationModel.cs
+++ b/src/NSwag.CodeGeneration.CSharp/Models/CSharpOperationModel.cs
@@ -169,6 +169,9 @@ namespace NSwag.CodeGeneration.CSharp.Models
             }
         }
 
+        /// <summary>Gets a value indicating whether a route name is available.</summary>
+        public bool HasRouteName => RouteName != null;
+
         /// <summary>Gets the route name for this operation.</summary>
         public string RouteName
         {
@@ -176,7 +179,9 @@ namespace NSwag.CodeGeneration.CSharp.Models
             {
                 var settings = _settings as SwaggerToCSharpControllerGeneratorSettings;
                 if (settings != null)
+                {
                     return settings.GetRouteName(_operation);
+                }
 
                 return null;
             }

--- a/src/NSwag.CodeGeneration.CSharp/SwaggerToCSharpControllerGeneratorSettings.cs
+++ b/src/NSwag.CodeGeneration.CSharp/SwaggerToCSharpControllerGeneratorSettings.cs
@@ -32,7 +32,9 @@ namespace NSwag.CodeGeneration.CSharp
         public string GetRouteName(SwaggerOperation operation)
         {
             if (RouteNamingStrategy == CSharpControllerRouteNamingStrategy.OperationId)
+            {
                 return operation.OperationId;
+            }
 
             return null;
         }

--- a/src/NSwag.CodeGeneration.CSharp/SwaggerToCSharpControllerGeneratorSettings.cs
+++ b/src/NSwag.CodeGeneration.CSharp/SwaggerToCSharpControllerGeneratorSettings.cs
@@ -23,6 +23,18 @@ namespace NSwag.CodeGeneration.CSharp
             ControllerStyle = CSharpControllerStyle.Partial;
             UseCancellationToken = false;
             AspNetNamespace = "System.Web.Http";
+            RouteNamingStrategy = CSharpControllerRouteNamingStrategy.None;
+        }
+
+        /// <summary>Returns the route name for a controller method.</summary>
+        /// <param name="operation">Swagger operation</param>
+        /// <returns>Route name.</returns>
+        public string GetRouteName(SwaggerOperation operation)
+        {
+            if (RouteNamingStrategy == CSharpControllerRouteNamingStrategy.OperationId)
+                return operation.OperationId;
+
+            return null;
         }
 
         /// <summary>Gets or sets the full name of the base class.</summary>
@@ -36,5 +48,8 @@ namespace NSwag.CodeGeneration.CSharp
 
         /// <summary>Gets or sets the ASP.NET namespace (default: 'System.Web.Http').</summary>
         public string AspNetNamespace { get; set; }
+
+        /// <summary>Gets or sets the strategy for naming routes (default: CSharpRouteNamingStrategy.None).</summary>
+        public CSharpControllerRouteNamingStrategy RouteNamingStrategy { get; set; }
     }
 }

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Controller.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Controller.liquid
@@ -52,7 +52,7 @@ public partial class {{ Class }}Controller : {% if HasBaseClass %}{{ BaseClass }
 {%         if operation.IsDeprecated -%}
     [System.Obsolete]
 {%         endif -%}
-    [{{ AspNetNamespace }}.Http{{ operation.HttpMethodUpper }}, {{ AspNetNamespace }}.Route("{{ operation.Path }}"{% if operation.RouteName != null %}, Name = "{{ operation.RouteName }}"{% endif %})]
+    [{{ AspNetNamespace }}.Http{{ operation.HttpMethodUpper }}, {{ AspNetNamespace }}.Route("{{ operation.Path }}"{% if operation.HasRouteName %}, Name = "{{ operation.RouteName }}"{% endif %})]
     public {% if operation.WrapResponse %}async System.Threading.Tasks.Task<HttpResponseMessage>{% else %}{{ operation.ResultType }}{% endif %} {{ operation.ActualOperationName }}({% for parameter in operation.Parameters %}{% if parameter.IsBody %}[{{ AspNetNamespace }}.FromBody] {% endif %}{{ parameter.Type }} {{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %} = null{% endif %}{% if parameter.IsLast == false or UseCancellationToken %}, {% endif %}{% endfor %}{% if UseCancellationToken %}System.Threading.CancellationToken cancellationToken{% endif %})
     {
 {%         if operation.WrapResponse -%}
@@ -90,7 +90,7 @@ public abstract class {{ Class }}ControllerBase : {% if HasBaseClass %}{{ BaseCl
 {%         if operation.IsDeprecated -%}
     [System.Obsolete]
 {%         endif -%}
-    [{{ AspNetNamespace }}.Http{{ operation.HttpMethodUpper }}, {{ AspNetNamespace }}.Route("{{ operation.Path }}"{% if operation.RouteName != null %}, Name = "{{ operation.RouteName }}"{% endif %})]
+    [{{ AspNetNamespace }}.Http{{ operation.HttpMethodUpper }}, {{ AspNetNamespace }}.Route("{{ operation.Path }}"{% if operation.HasRouteName %}, Name = "{{ operation.RouteName }}"{% endif %})]
     public abstract {%  if operation.WrapResponse %}System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>{% else %}{{ operation.ResultType }}{% endif %} {{ operation.ActualOperationName }}({% for parameter in operation.Parameters %}{% if parameter.IsBody %}[{{ AspNetNamespace }}.FromBody] {% endif %}{{ parameter.Type }} {{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %} = null{% endif %}{% if parameter.IsLast == false or UseCancellationToken %}, {% endif %}{% endfor %}{% if UseCancellationToken %}System.Threading.CancellationToken cancellationToken{% endif %});
 
 {%     endfor -%}

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Controller.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Controller.liquid
@@ -52,7 +52,7 @@ public partial class {{ Class }}Controller : {% if HasBaseClass %}{{ BaseClass }
 {%         if operation.IsDeprecated -%}
     [System.Obsolete]
 {%         endif -%}
-    [{{ AspNetNamespace }}.Http{{ operation.HttpMethodUpper }}, {{ AspNetNamespace }}.Route("{{ operation.Path }}")]
+    [{{ AspNetNamespace }}.Http{{ operation.HttpMethodUpper }}, {{ AspNetNamespace }}.Route("{{ operation.Path }}"{% if operation.RouteName != null %}, Name = "{{ operation.RouteName }}"{% endif %})]
     public {% if operation.WrapResponse %}async System.Threading.Tasks.Task<HttpResponseMessage>{% else %}{{ operation.ResultType }}{% endif %} {{ operation.ActualOperationName }}({% for parameter in operation.Parameters %}{% if parameter.IsBody %}[{{ AspNetNamespace }}.FromBody] {% endif %}{{ parameter.Type }} {{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %} = null{% endif %}{% if parameter.IsLast == false or UseCancellationToken %}, {% endif %}{% endfor %}{% if UseCancellationToken %}System.Threading.CancellationToken cancellationToken{% endif %})
     {
 {%         if operation.WrapResponse -%}
@@ -90,7 +90,7 @@ public abstract class {{ Class }}ControllerBase : {% if HasBaseClass %}{{ BaseCl
 {%         if operation.IsDeprecated -%}
     [System.Obsolete]
 {%         endif -%}
-    [{{ AspNetNamespace }}.Http{{ operation.HttpMethodUpper }}, {{ AspNetNamespace }}.Route("{{ operation.Path }}")]
+    [{{ AspNetNamespace }}.Http{{ operation.HttpMethodUpper }}, {{ AspNetNamespace }}.Route("{{ operation.Path }}"{% if operation.RouteName != null %}, Name = "{{ operation.RouteName }}"{% endif %})]
     public abstract {%  if operation.WrapResponse %}System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>{% else %}{{ operation.ResultType }}{% endif %} {{ operation.ActualOperationName }}({% for parameter in operation.Parameters %}{% if parameter.IsBody %}[{{ AspNetNamespace }}.FromBody] {% endif %}{{ parameter.Type }} {{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %} = null{% endif %}{% if parameter.IsLast == false or UseCancellationToken %}, {% endif %}{% endfor %}{% if UseCancellationToken %}System.Threading.CancellationToken cancellationToken{% endif %});
 
 {%     endfor -%}

--- a/src/NSwag.Commands/Commands/CodeGeneration/SwaggerToCSharpControllerCommand.cs
+++ b/src/NSwag.Commands/Commands/CodeGeneration/SwaggerToCSharpControllerCommand.cs
@@ -50,6 +50,13 @@ namespace NSwag.Commands.CodeGeneration
             set { Settings.AspNetNamespace = value; }
         }
 
+        [Argument(Name = "RouteNamingStrategy", Description = "The strategy for naming controller routes (none, operationid; default: none).", IsRequired = false)]
+        public CSharpControllerRouteNamingStrategy RouteNamingStrategy
+        {
+            get { return Settings.RouteNamingStrategy; }
+            set { Settings.RouteNamingStrategy = value; }
+        }
+
         public override async Task<object> RunAsync(CommandLineProcessor processor, IConsoleHost host)
         {
             var code = await RunAsync();

--- a/src/NSwagStudio/ViewModels/CodeGenerators/SwaggerToCSharpControllerGeneratorViewModel.cs
+++ b/src/NSwagStudio/ViewModels/CodeGenerators/SwaggerToCSharpControllerGeneratorViewModel.cs
@@ -30,22 +30,27 @@ namespace NSwagStudio.ViewModels.CodeGenerators
             }
         }
 
-        /// <summary>Gets the list of operation modes. </summary>
+        /// <summary>Gets the list of operation modes.</summary>
         public OperationGenerationMode[] OperationGenerationModes { get; } = Enum.GetNames(typeof(OperationGenerationMode))
             .Select(t => (OperationGenerationMode)Enum.Parse(typeof(OperationGenerationMode), t))
             .ToArray();
 
-        /// <summary>Gets the list of class styles. </summary>
+        /// <summary>Gets the list of class styles.</summary>
         public CSharpClassStyle[] ClassStyles { get; } = Enum.GetNames(typeof(CSharpClassStyle))
             .Select(t => (CSharpClassStyle)Enum.Parse(typeof(CSharpClassStyle), t))
             .ToArray();
 
-        /// <summary>Gets the list of class styles. </summary>
+        /// <summary>Gets the list of class styles.</summary>
         public CSharpControllerStyle[] ControllerStyles { get; } = Enum.GetNames(typeof(CSharpControllerStyle))
             .Select(t => (CSharpControllerStyle)Enum.Parse(typeof(CSharpControllerStyle), t))
             .ToArray();
 
-        /// <summary>Gets or sets the client code. </summary>
+        /// <summary>Gets the list of route naming strategies.</summary>
+        public CSharpControllerRouteNamingStrategy[] RouteNamingStrategies { get; } = Enum.GetNames(typeof(CSharpControllerRouteNamingStrategy))
+            .Select(t => (CSharpControllerRouteNamingStrategy)Enum.Parse(typeof(CSharpControllerRouteNamingStrategy), t))
+            .ToArray();
+
+        /// <summary>Gets or sets the client code.</summary>
         public string ClientCode
         {
             get { return _clientCode; }

--- a/src/NSwagStudio/Views/CodeGenerators/SwaggerToCSharpControllerGeneratorView.xaml
+++ b/src/NSwagStudio/Views/CodeGenerators/SwaggerToCSharpControllerGeneratorView.xaml
@@ -57,6 +57,11 @@
                             <CheckBox IsChecked="{Binding Command.GenerateOptionalParameters, Mode=TwoWay}" 
                                       Content="Generate optional parameters (reorder parameters (required first, optional at the end) and generate optional parameters)" Margin="0,0,0,12" />
 
+                            <TextBlock Text="Route Naming Strategy" FontWeight="Bold" Margin="0,0,0,6" />
+                            <ComboBox SelectedItem="{Binding Command.RouteNamingStrategy, Mode=TwoWay}" 
+                                      ToolTip="RouteNamingStrategy"
+                                      ItemsSource="{Binding RouteNamingStrategies}" Margin="0,0,0,12" />
+
                             <StackPanel Visibility="{Binding Command.WrapResponses, Converter={StaticResource VisibilityConverter}}">
                                 <TextBlock Text="Methods where responses are wrapped (empty for all, 'ControllerName.MethodName', comma separated)" FontWeight="Bold" Margin="0,0,0,6" />
                                 <TextBox ToolTip="WrapResponseMethods" 


### PR DESCRIPTION
This PR resolves #1452 