### PR TITLE
Add title, description and version to C# controller template model

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Models/CSharpControllerTemplateModel.cs
+++ b/src/NSwag.CodeGeneration.CSharp/Models/CSharpControllerTemplateModel.cs
@@ -76,5 +76,14 @@ namespace NSwag.CodeGeneration.CSharp.Models
 
         /// <summary>Gets a value  indicating whether to allow adding cancellation token.</summary>
         public bool UseCancellationToken => _settings.UseCancellationToken;
+
+        /// <summary>Gets the Title.</summary>
+        public string Title => _document.Info.Title;
+
+        /// <summary>Gets the Description.</summary>
+        public string Description => _document.Info.Description;
+
+        /// <summary>Gets the API version.</summary>
+        public string Version => _document.Info.Version;
     }
 }


### PR DESCRIPTION
Add title, description and version from Swagger info to C# controller template model so that they can be used in templates.