### PR TITLE
Perform exact request path matching for UI index

### DIFF
--- a/src/NSwag.AspNet.Owin/Middlewares/SwaggerUiIndexMiddleware.cs
+++ b/src/NSwag.AspNet.Owin/Middlewares/SwaggerUiIndexMiddleware.cs
@@ -23,7 +23,7 @@ namespace NSwag.AspNet.Owin.Middlewares
 
         public override async Task Invoke(IOwinContext context)
         {
-            if (context.Request.Path.HasValue && context.Request.Path.Value.Trim('/').StartsWith(_indexPath.Trim('/'), StringComparison.OrdinalIgnoreCase))
+            if (context.Request.Path.HasValue && string.Equals(context.Request.Path.Value.Trim('/'), _indexPath.Trim('/'), StringComparison.OrdinalIgnoreCase))
             {
                 var stream = typeof(SwaggerUiIndexMiddleware<T>).Assembly.GetManifestResourceStream(_resourcePath);
                 using (var reader = new StreamReader(stream))

--- a/src/NSwag.AspNetCore/Middlewares/SwaggerUiIndexMiddleware.cs
+++ b/src/NSwag.AspNetCore/Middlewares/SwaggerUiIndexMiddleware.cs
@@ -25,7 +25,7 @@ namespace NSwag.AspNetCore.Middlewares
 
         public async Task Invoke(HttpContext context)
         {
-            if (context.Request.Path.HasValue && context.Request.Path.Value.Trim('/').StartsWith(_indexPath.Trim('/'), StringComparison.OrdinalIgnoreCase))
+            if (context.Request.Path.HasValue && string.Equals(context.Request.Path.Value.Trim('/'), _indexPath.Trim('/'), StringComparison.OrdinalIgnoreCase))
             {
                 var stream = typeof(SwaggerUiIndexMiddleware<T>).GetTypeInfo().Assembly.GetManifestResourceStream(_resourcePath);
                 using (var reader = new StreamReader(stream))


### PR DESCRIPTION
If the swagger ui route is `/swagger` only return the
index if `/swagger/index.html` is requested.

StartsWith causes web vulnerability scanners to report significant
number of false positives because requests to potentially
vulnerable URLs like `/swagger/index.html/.htacces` return 200.