### PR TITLE
Add local nuget repository as refPaths

### DIFF
--- a/samples/WithoutMiddleware/Sample.AspNetCore20/nswag_assembly.nswag
+++ b/samples/WithoutMiddleware/Sample.AspNetCore20/nswag_assembly.nswag
@@ -22,7 +22,8 @@
       "assemblyPaths": [
         "bin/$(configuration)/netcoreapp2.0/Sample.AspNetCore20.dll"
       ],
-      "referencePaths": []
+      "referencePaths": [],
+      "useNuGetCache": false
     }
   },
   "codeGenerators": {}

--- a/samples/WithoutMiddleware/Sample.AspNetCore21/nswag_assembly.nswag
+++ b/samples/WithoutMiddleware/Sample.AspNetCore21/nswag_assembly.nswag
@@ -22,7 +22,8 @@
       "assemblyPaths": [
         "bin/$(configuration)/netcoreapp2.1/Sample.AspNetCore21.dll"
       ],
-      "referencePaths": []
+      "referencePaths": [],
+      "useNuGetCache": false
     }
   },
   "codeGenerators": {}

--- a/src/NSwag.Commands/Commands/IsolatedCommandBase.cs
+++ b/src/NSwag.Commands/Commands/IsolatedCommandBase.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using NConsole;
 using Newtonsoft.Json;
@@ -37,6 +38,9 @@ namespace NSwag.Commands
         [Argument(Name = "ReferencePaths", IsRequired = false, Description = "The paths to search for referenced assembly files (comma separated).")]
         public string[] ReferencePaths { get; set; } = new string[0];
 
+        [Argument(Name = "LoadDefaultNugetCaches", IsRequired = false, Description = "Determines if local Nuget's cache folder should be put in the ReferencePaths by default")]
+        public bool LoadDefaultNugetCaches { get; set; } = false;
+
         public abstract Task<object> RunAsync(CommandLineProcessor processor, IConsoleHost host);
 
         protected async Task<TResult> RunIsolatedAsync(string configurationFile)
@@ -44,6 +48,17 @@ namespace NSwag.Commands
             var assemblyDirectory = AssemblyPaths.Any() ? Path.GetDirectoryName(Path.GetFullPath(PathUtilities.ExpandFileWildcards(AssemblyPaths).First())) : configurationFile;
             var bindingRedirects = GetBindingRedirects();
             var assemblies = GetAssemblies(assemblyDirectory);
+
+            Console.WriteLine($"LoadDefaultNugetCaches: {LoadDefaultNugetCaches}");
+
+            if (LoadDefaultNugetCaches)
+            {
+                var defaultNugetPackages = LoadDefaultNugetCache();
+                ReferencePaths = ReferencePaths.Concat(defaultNugetPackages).ToArray();
+
+                Console.WriteLine("Loaded Reference Paths");
+                Console.WriteLine(string.Join(", ", ReferencePaths));
+            }
 
             using (var isolated = new AppDomainIsolation<IsolatedCommandAssemblyLoader<TResult>>(assemblyDirectory, AssemblyConfig, bindingRedirects, assemblies))
             {
@@ -72,6 +87,14 @@ namespace NSwag.Commands
                 .Concat(referencePaths)
                 .Distinct()
                 .ToArray();
+        }
+
+        private static string[] LoadDefaultNugetCache()
+        {
+            var envHome = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "HOMEPATH" : "HOME";
+            var home = Environment.GetEnvironmentVariable(envHome);
+
+            return new[] { Path.Combine(home, ".nuget", "packages") };
         }
 
 #if NET451

--- a/src/NSwag.Commands/Commands/IsolatedCommandBase.cs
+++ b/src/NSwag.Commands/Commands/IsolatedCommandBase.cs
@@ -38,8 +38,8 @@ namespace NSwag.Commands
         [Argument(Name = "ReferencePaths", IsRequired = false, Description = "The paths to search for referenced assembly files (comma separated).")]
         public string[] ReferencePaths { get; set; } = new string[0];
 
-        [Argument(Name = "LoadDefaultNugetCaches", IsRequired = false, Description = "Determines if local Nuget's cache folder should be put in the ReferencePaths by default")]
-        public bool LoadDefaultNugetCaches { get; set; } = false;
+        [Argument(Name = "UseNuGetCache", IsRequired = false, Description = "Determines if local Nuget's cache folder should be put in the ReferencePaths by default")]
+        public bool UseNuGetCache { get; set; } = false;
 
         public abstract Task<object> RunAsync(CommandLineProcessor processor, IConsoleHost host);
 
@@ -49,7 +49,7 @@ namespace NSwag.Commands
             var bindingRedirects = GetBindingRedirects();
             var assemblies = GetAssemblies(assemblyDirectory);
             
-            if (LoadDefaultNugetCaches)
+            if (UseNuGetCache)
             {
                 var defaultNugetPackages = LoadDefaultNugetCache();
                 ReferencePaths = ReferencePaths.Concat(defaultNugetPackages).ToArray();

--- a/src/NSwag.Commands/Commands/IsolatedCommandBase.cs
+++ b/src/NSwag.Commands/Commands/IsolatedCommandBase.cs
@@ -49,15 +49,10 @@ namespace NSwag.Commands
             var bindingRedirects = GetBindingRedirects();
             var assemblies = GetAssemblies(assemblyDirectory);
             
-            Console.WriteLine($"LoadDefaultNugetCaches: {LoadDefaultNugetCaches}");
-
             if (LoadDefaultNugetCaches)
             {
                 var defaultNugetPackages = LoadDefaultNugetCache();
                 ReferencePaths = ReferencePaths.Concat(defaultNugetPackages).ToArray();
-
-                Console.WriteLine("Loaded Reference Paths");
-                Console.WriteLine(string.Join(", ", ReferencePaths));
             }
 
             using (var isolated = new AppDomainIsolation<IsolatedCommandAssemblyLoader<TResult>>(assemblyDirectory, AssemblyConfig, bindingRedirects, assemblies))

--- a/src/NSwag.Commands/Commands/IsolatedCommandBase.cs
+++ b/src/NSwag.Commands/Commands/IsolatedCommandBase.cs
@@ -48,7 +48,7 @@ namespace NSwag.Commands
             var assemblyDirectory = AssemblyPaths.Any() ? Path.GetDirectoryName(Path.GetFullPath(PathUtilities.ExpandFileWildcards(AssemblyPaths).First())) : configurationFile;
             var bindingRedirects = GetBindingRedirects();
             var assemblies = GetAssemblies(assemblyDirectory);
-
+            
             Console.WriteLine($"LoadDefaultNugetCaches: {LoadDefaultNugetCaches}");
 
             if (LoadDefaultNugetCaches)
@@ -88,13 +88,14 @@ namespace NSwag.Commands
                 .Distinct()
                 .ToArray();
         }
-
+        
         private static string[] LoadDefaultNugetCache()
         {
             var envHome = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "HOMEPATH" : "HOME";
             var home = Environment.GetEnvironmentVariable(envHome);
+            var path = Path.Combine(home, ".nuget", "packages");
 
-            return new[] { Path.Combine(home, ".nuget", "packages") };
+            return new[] { Path.GetFullPath(path) };
         }
 
 #if NET451

--- a/src/NSwag.Commands/Commands/SwaggerGeneration/ListWebApiControllersCommand.cs
+++ b/src/NSwag.Commands/Commands/SwaggerGeneration/ListWebApiControllersCommand.cs
@@ -6,7 +6,6 @@
 // <author>Rico Suter, mail@rsuter.com</author>
 //-----------------------------------------------------------------------
 
-using System;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -15,7 +14,6 @@ using NJsonSchema.Infrastructure;
 using NSwag.AssemblyLoader.Utilities;
 using NSwag.SwaggerGeneration.WebApi;
 using System.IO;
-using System.Runtime.InteropServices;
 using NSwag.Commands.SwaggerGeneration.WebApi;
 
 namespace NSwag.Commands.SwaggerGeneration

--- a/src/NSwag.Commands/Commands/SwaggerGeneration/ListWebApiControllersCommand.cs
+++ b/src/NSwag.Commands/Commands/SwaggerGeneration/ListWebApiControllersCommand.cs
@@ -31,8 +31,6 @@ namespace NSwag.Commands.SwaggerGeneration
 
         public override async Task<object> RunAsync(CommandLineProcessor processor, IConsoleHost host)
         {
-            Console.WriteLine($"LoadDefaultNugetCaches: {LoadDefaultNugetCaches}");
-
             if (!string.IsNullOrEmpty(File))
             {
                 var document = await NSwagDocument.LoadWithTransformationsAsync(File, Variables);
@@ -41,15 +39,6 @@ namespace NSwag.Commands.SwaggerGeneration
                 AssemblyPaths = command.AssemblyPaths;
                 AssemblyConfig = command.AssemblyConfig;
                 ReferencePaths = command.ReferencePaths;
-
-                if (LoadDefaultNugetCaches)
-                {
-                    var defaultNugetPackages = LoadDefaultNugetCache();
-                    ReferencePaths = ReferencePaths.Concat(defaultNugetPackages).ToArray();
-
-                    Console.WriteLine("Loaded Reference Paths");
-                    Console.WriteLine(string.Join(", ", ReferencePaths));
-                }
             }
 
             var classNames = await RunIsolatedAsync(!string.IsNullOrEmpty(File) ? Path.GetDirectoryName(File) : null);
@@ -77,15 +66,5 @@ namespace NSwag.Commands.SwaggerGeneration
                 .OrderBy(c => c)
                 .ToArray();
         }
-
-        
-        private static string[] LoadDefaultNugetCache()
-        {
-            var envHome = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "HOMEPATH" : "HOME";
-            var home = Environment.GetEnvironmentVariable(envHome);
-
-            return new[] { Path.Combine(home, ".nuget", "packages") };
-        }
-
     }
 }

--- a/src/NSwag.Sample.NETCore20/nswag.json
+++ b/src/NSwag.Sample.NETCore20/nswag.json
@@ -19,7 +19,8 @@
       "assemblyPaths": [
         "bin/Debug/netcoreapp2.0/NSwag.Sample.NETCore20.dll"
       ],
-      "referencePaths": []
+      "referencePaths": [],
+      "useNuGetCache": false
     }
   },
   "codeGenerators": {}

--- a/src/NSwagStudio/ViewModels/SwaggerGenerators/AssemblyTypeToSwaggerGeneratorViewModel.cs
+++ b/src/NSwagStudio/ViewModels/SwaggerGenerators/AssemblyTypeToSwaggerGeneratorViewModel.cs
@@ -60,23 +60,6 @@ namespace NSwagStudio.ViewModels.SwaggerGenerators
             }
         }
 
-        /// <summary>Gets or sets the reference path. </summary>
-        public string ReferencePaths
-        {
-            get
-            {
-                return Command.ReferencePaths != null ? string.Join(",", Command.ReferencePaths) : "";
-            }
-            set
-            {
-                if (!string.IsNullOrEmpty(value))
-                    Command.ReferencePaths = value.Split(',').Select(n => n.Trim()).Where(n => !string.IsNullOrEmpty(n)).ToArray();
-                else
-                    Command.ReferencePaths = new string[] { };
-                RaisePropertyChanged(() => ReferencePaths);
-            }
-        }
-
         /// <summary>Gets the default enum handlings. </summary>
         public EnumHandling[] EnumHandlings { get; } = Enum.GetNames(typeof(EnumHandling))
             .Select(t => (EnumHandling)Enum.Parse(typeof(EnumHandling), t))

--- a/src/NSwagStudio/Views/SwaggerGenerators/AspNetCoreToSwaggerGeneratorView.xaml
+++ b/src/NSwagStudio/Views/SwaggerGenerators/AspNetCoreToSwaggerGeneratorView.xaml
@@ -91,6 +91,10 @@
                     <TextBlock Text="Paths to search for referenced assembly files (multiple on separate lines)" FontWeight="Bold" Margin="0,0,0,6" />
                     <TextBox Text="{Binding Command.ReferencePaths, Mode=TwoWay, Converter={StaticResource StringArrayConverter}}" 
                              ToolTip="ReferencePaths" Height="52" AcceptsReturn="True" VerticalScrollBarVisibility="Visible" Margin="0,0,0,12" />
+
+                    <CheckBox IsChecked="{Binding Command.UseNuGetCache, Mode=TwoWay}" Margin="0,0,0,12" ToolTip="UseNuGetCache">
+                        <TextBlock Text="Add local Nuget's cache folder to reference paths" TextWrapping="Wrap" />
+                    </CheckBox>
                 </StackPanel>
             </GroupBox>
 

--- a/src/NSwagStudio/Views/SwaggerGenerators/AssemblyTypeToSwaggerGeneratorView.xaml
+++ b/src/NSwagStudio/Views/SwaggerGenerators/AssemblyTypeToSwaggerGeneratorView.xaml
@@ -53,8 +53,13 @@
                                             DefaultExtension=".config"
                                             Filter="Config Files (.config)|*.config"/>
 
-                    <TextBlock Text="Paths to search for referenced assembly files (comma separated)" FontWeight="Bold" Margin="0,0,0,6" />
-                    <TextBox Text="{Binding ReferencePaths, Mode=TwoWay}" Margin="0,0,0,12" />
+                    <TextBlock Text="Paths to search for referenced assembly files (multiple on separate lines)" FontWeight="Bold" Margin="0,0,0,6" />
+                    <TextBox Text="{Binding Command.ReferencePaths, Mode=TwoWay, Converter={StaticResource StringArrayConverter}}" 
+                             ToolTip="ReferencePaths" Height="52" AcceptsReturn="True" VerticalScrollBarVisibility="Visible" Margin="0,0,0,12" />
+
+                    <CheckBox IsChecked="{Binding Command.UseNuGetCache, Mode=TwoWay}" Margin="0,0,0,12" ToolTip="UseNuGetCache">
+                        <TextBlock Text="Add local Nuget's cache folder to reference paths" TextWrapping="Wrap" />
+                    </CheckBox>
 
                     <Button Command="{Binding LoadAssembliesCommand}" VerticalAlignment="Stretch"
                             Padding="8,4,8,4" Margin="0,0,0,12" Content="Load Assembly" />

--- a/src/NSwagStudio/Views/SwaggerGenerators/WebApiToSwaggerGeneratorView.xaml
+++ b/src/NSwagStudio/Views/SwaggerGenerators/WebApiToSwaggerGeneratorView.xaml
@@ -56,6 +56,10 @@
                     <TextBox Text="{Binding Command.ReferencePaths, Mode=TwoWay, Converter={StaticResource StringArrayConverter}}" 
                              ToolTip="ReferencePaths" Height="52" AcceptsReturn="True" VerticalScrollBarVisibility="Visible" Margin="0,0,0,12" />
 
+                    <CheckBox IsChecked="{Binding Command.UseNuGetCache, Mode=TwoWay}" Margin="0,0,0,12" ToolTip="UseNuGetCache">
+                        <TextBlock Text="Add local Nuget's cache folder to reference paths" TextWrapping="Wrap" />
+                    </CheckBox>
+
                     <CheckBox IsChecked="{Binding Command.IsAspNetCore, Mode=TwoWay}" 
                               ToolTip="IsAspNetCore" Margin="0,0,0,12">
                         <TextBlock Text="Assembly is using ASP.NET Core" TextWrapping="Wrap" />

--- a/src/Samples/DemoWeb.nswag
+++ b/src/Samples/DemoWeb.nswag
@@ -5,6 +5,7 @@
         "../NSwag.Demo.Web/bin/NSwag.Demo.Web.dll"
       ],
       "referencePaths": [],
+      "useNuGetCache": false,
       "isAspNetCore": false,
       "controllerNames": [
         "NSwag.Demo.Web.Controllers.TestController"


### PR DESCRIPTION
When working with Assembly Loader for dotnet core we found out that we have a lot of issues with missing libraries in the build directory. Fix that is working for us was to add a local nuget packages folder to the `referencePaths` array in the `nswag.json` config file.

However this is problematic as:
1) The path that is given there do not expand env variables
2) The path is different per operating system.

To fix that we used an approach to add a new configuration parameter in the `SwaggerGenerator -> WebApiToSwagger` section named a `loadDefaultNugetCaches` which is false by default (it means by default it does not change the current NSwag behaviour)

When you set a `loadDefaultNugetCaches` to `true` then depending on your OS, a proper path to the local Nuget packages is added to the `referencePaths` section in the background.

And this resolves our issue with the NSwag assembly loader for dotnet core apps.