### PR TITLE
C# Client: Enhance exception message with status and response

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/File.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/File.liquid
@@ -118,7 +118,7 @@ namespace {{ Namespace }}
         public System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>> Headers { get; private set; }
 
         public {{ exceptionClassName }}(string message, int statusCode, string response, System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>> headers, System.Exception innerException) 
-            : base(message + "\n\nStatus: " + statusCode + "\nResponse: \n" + response, innerException)
+            : base(message + "\n\nStatus: " + statusCode + "\nResponse: \n" + response.Substring(0, response.Length >= 512 ? 512 : str.Length), innerException)
         {
             StatusCode = statusCode;
             Response = response; 

--- a/src/NSwag.CodeGeneration.CSharp/Templates/File.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/File.liquid
@@ -118,7 +118,7 @@ namespace {{ Namespace }}
         public System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>> Headers { get; private set; }
 
         public {{ exceptionClassName }}(string message, int statusCode, string response, System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>> headers, System.Exception innerException) 
-            : base(message, innerException)
+            : base($"{message} [status: {statusCode}, response: {response}]", innerException)
         {
             StatusCode = statusCode;
             Response = response; 

--- a/src/NSwag.CodeGeneration.CSharp/Templates/File.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/File.liquid
@@ -118,7 +118,7 @@ namespace {{ Namespace }}
         public System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>> Headers { get; private set; }
 
         public {{ exceptionClassName }}(string message, int statusCode, string response, System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>> headers, System.Exception innerException) 
-            : base($"{message} [status: {statusCode}, response: {response}]", innerException)
+            : base(message + "\n\nStatus: " + statusCode + "\nResponse: \n" + response, innerException)
         {
             StatusCode = statusCode;
             Response = response; 


### PR DESCRIPTION
When a unit test throws an exception, [xUnit](https://xunit.github.io/) outputs
Exception.Message. But SwaggerException.Message does not contain the HTTP
status code or the HTTP response, which are crucial to describe the exception.

    Xavo.DemandClient.SwaggerException : MyMessage
       at SwaggerTests.SwaggerTests.SwaggerTest() in C:\...\SwaggerTests.cs:line 12

Enhance the exception message by adding the HTTP status code and HTTP response.

Although the exception contains The HTTP status code and HTTP response as
properties, the unit tests cannot be taught to output them without explicitly
handling them in every single test. An alternative approach is to proxy the
swagger clients in order to intercept method invocations and wrap the exception
in a custom exception (using DynamicProxy or DynamicObject+ImpromptuInterface).
This is however not possible because the methods are neither virtual nor do
they implement an interface. It also seems to be impossible to intercept the
test methods themselves.

Closes #1605.