### PR TITLE
Added more Swagger UI 3 display settings

### DIFF
--- a/src/NSwag.AspNet.Owin/SwaggerUi3/index.html
+++ b/src/NSwag.AspNet.Owin/SwaggerUi3/index.html
@@ -45,6 +45,22 @@ window.onload = function() {
   }
   var urls = {Urls};
 
+  const disableTryItOutPlugin = function() {
+    return {
+      statePlugins: {
+      spec: {
+        wrapSelectors: {
+          allowTryItOutFor: function() {
+            return function() {
+                return {EnableTryItOut};
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
   // Build a system
   var ui = SwaggerUIBundle({
     url: url,
@@ -54,6 +70,9 @@ window.onload = function() {
     docExpansion: "{DocExpansion}",
     apisSorter: "{ApisSorter}",
     operationsSorter: "{OperationsSorter}",
+    defaultModelsExpandDepth: {DefaultModelsExpandDepth},
+    defaultModelExpandDepth: {DefaultModelExpandDepth},
+    tagSorter: "{TagSorter}",
 
     dom_id: '#swagger-ui',
     deepLinking: true,
@@ -62,7 +81,8 @@ window.onload = function() {
       SwaggerUIStandalonePreset
     ],
     plugins: [
-      SwaggerUIBundle.plugins.DownloadUrl
+        SwaggerUIBundle.plugins.DownloadUrl,
+        disableTryItOutPlugin
     ],
     layout: "StandaloneLayout"
   });

--- a/src/NSwag.AspNetCore/SwaggerUi3Settings.cs
+++ b/src/NSwag.AspNetCore/SwaggerUi3Settings.cs
@@ -39,6 +39,18 @@ namespace NSwag.AspNetCore
         /// <summary>Specifies the operations sorter in Swagger UI 3.</summary>
         public string OperationsSorter { get; set; } = "none";
 
+        /// <summary>The default expansion depth for models (set to -1 completely hide the models) in Swagger UI 3.</summary>
+        public int DefaultModelsExpandDepth { get; set; } = 1;
+
+        /// <summary>The default expansion depth for the model on the model-example section in Swagger UI 3.</summary>
+        public int DefaultModelExpandDepth { get; set; } = 1;
+
+        /// <summary>Specifies the tag sorter in Swagger UI 3</summary>
+        public string TagSorter { get; set; } = "none";
+
+        /// <summary>Specifies whether the "Try it out" option is enabled in Swagger UI 3.</summary>
+        public bool EnableTryItOut { get; set; } = true;
+
         /// <summary>Gets or sets the server URL.</summary>
         public string ServerUrl { get; set; } = "";
 
@@ -66,6 +78,10 @@ namespace NSwag.AspNetCore
             html = html.Replace("{DocExpansion}", DocExpansion);
             html = html.Replace("{ApisSorter}", ApisSorter);
             html = html.Replace("{OperationsSorter}", OperationsSorter);
+            html = html.Replace("{DefaultModelsExpandDepth}", DefaultModelsExpandDepth.ToString());
+            html = html.Replace("{DefaultModelExpandDepth}", DefaultModelExpandDepth.ToString());
+            html = html.Replace("{TagSorter}", TagSorter);
+            html = html.Replace("{EnableTryItOut}", EnableTryItOut.ToString().ToLower());
             html = html.Replace("{RedirectUrl}", string.IsNullOrEmpty(ServerUrl) ?
                 "window.location.origin + \"" + SwaggerUiRoute + "/oauth2-redirect.html\"" :
                 "\"" + ServerUrl + SwaggerUiRoute + "/oauth2-redirect.html\"");


### PR DESCRIPTION
There is a number of Swagger UI 3 display settings that aren't currently configurable.

I specifically wanted the ability to hide the Models section at the bottom, which if you pass `-1` to `defaultModelsExpandDepth` will hide it.

I also included a couple of other options that seemed appropriate to include.

I also included a custom plugin to allow the disabling of the `Try it out` options. This wasn't something I wanted in our UI (as our auth is a bit fiddly), so this just removes that button.