### PR TITLE
RxJS: Import from only if needed, closes #1533

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript/Templates/File.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/File.liquid
@@ -23,7 +23,7 @@ import 'rxjs/add/operator/catch';
 import { Observable } from 'rxjs/Observable';
 {%             else -%}
 import { mergeMap as {{ Framework.RxJs.ObservableMergeMapMethod }}, catchError as {{ Framework.RxJs.ObservableCatchMethod }} } from 'rxjs/operators';
-import { Observable, from as {{ Framework.RxJs.ObservableFromMethod }}, throwError as {{ Framework.RxJs.ObservableThrowMethod }}, of as {{ Framework.RxJs.ObservableOfMethod }} } from 'rxjs';
+import { Observable, {% if UseTransformOptionsMethod %}from as {{ Framework.RxJs.ObservableFromMethod }}, {% endif %}throwError as {{ Framework.RxJs.ObservableThrowMethod }}, of as {{ Framework.RxJs.ObservableOfMethod }} } from 'rxjs';
 {%             endif -%}
 import { Injectable, Inject, Optional, {{ Framework.Angular.InjectionTokenType }} } from '@angular/core';
 {%             if Framework.Angular.UseHttpClient -%}


### PR DESCRIPTION
Have been waiting for this feature for a while. Not sure why the issue is closed without the code pulled in.

Are there any remaining issues preventing this from merging?