### PR TITLE
Quick fix: Correct typo in `NSwag.Sample.NETCore20.Startup`

### DIFF
--- a/src/NSwag.Sample.NETCore20/Startup.cs
+++ b/src/NSwag.Sample.NETCore20/Startup.cs
@@ -80,7 +80,7 @@ namespace NSwag.Sample.NETCore20
             //// Add OpenAPI 3.0 document serving middleware
             app.UseSwagger(options =>
             {
-                options.DocumentName = "swagger";
+                options.DocumentName = "openapi";
                 options.Path = "/openapi/v1/openapi.json";
             });
 


### PR DESCRIPTION
- change /openapi/v1/openapi.json to host the `"openapi"` document