### PR TITLE
[C# Client] Boolean query parameters are now lowercase

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ConvertToString.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ConvertToString.liquid
@@ -17,6 +17,9 @@
             }
         }
     }
+    else if (value is bool) {
+        return System.Convert.ToString(value, cultureInfo).ToLower();
+    }
     else if (value is byte[])
     {
         return System.Convert.ToBase64String((byte[]) value);

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ConvertToString.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.ConvertToString.liquid
@@ -18,7 +18,7 @@
         }
     }
     else if (value is bool) {
-        return System.Convert.ToString(value, cultureInfo).ToLower();
+        return System.Convert.ToString(value, cultureInfo).ToLowerInvariant();
     }
     else if (value is byte[])
     {


### PR DESCRIPTION
The `ConvertToString` method of generated C# clients serializes boolean values to `True` and `False`, which means that boolean values in query parameters are either `True` or `False`.

The OpenAPI 3.0 specification does not specify how boolean values are to be serialized when they are query parameters. However, when using a nodejs server generated by https://editor.swagger.io/, requests with `queryParam=True` and `queryParam=False` fail the built in validation in the server. The validation code is taken from `swagger-tools`, and can be seen here: https://github.com/apigee-127/swagger-tools/blob/master/lib/validators.js#L484 . I have tested that lower-casing the boolean values makes the requests pass this validation.

From this, and from doing some googling, it would seem that people around the internet are of the opinion that boolean query parameters should either be serialized as "true" and "false", or alternatively "1" and "0".

I propose that one should use "true" and "false".

Edit: Sorry about the useless second commit. It would seem that the GitHub code editor automatically adds a newline at the end of the file. I can create a new PR if this is problematic.