### PR TITLE
Change default settings

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/SwaggerToCSharpClientGeneratorSettings.cs
+++ b/src/NSwag.CodeGeneration.CSharp/SwaggerToCSharpClientGeneratorSettings.cs
@@ -28,7 +28,7 @@ namespace NSwag.CodeGeneration.CSharp
             QueryNullValue = "";
             GenerateBaseUrlProperty = true;
             ExposeJsonSerializerSettings = false;
-
+            InjectHttpClient = true;
             ProtectedMethods = new string[0];
         }
 
@@ -44,7 +44,7 @@ namespace NSwag.CodeGeneration.CSharp
         /// <summary>Gets or sets the name of the exception class (supports the '{controller}' placeholder, default 'SwaggerException').</summary>
         public string ExceptionClass { get; set; }
 
-        /// <summary>Gets or sets a value indicating whether an HttpClient instance is injected into the client.</summary>
+        /// <summary>Gets or sets a value indicating whether an HttpClient instance is injected into the client (default: true).</summary>
         public bool InjectHttpClient { get; set; }
 
         /// <summary>Gets or sets a value indicating whether to dispose the HttpClient (injected HttpClient is never disposed, default: true).</summary>

--- a/src/NSwag.CodeGeneration.CSharp/SwaggerToCSharpGeneratorSettings.cs
+++ b/src/NSwag.CodeGeneration.CSharp/SwaggerToCSharpGeneratorSettings.cs
@@ -24,6 +24,20 @@ namespace NSwag.CodeGeneration.CSharp
             {
                 Namespace = "MyNamespace",
                 SchemaType = SchemaType.Swagger2,
+
+                // TODO: Remove these defaults when NJS is updated with them
+                ClassStyle = CSharpClassStyle.Poco,
+
+                DateType = "System.DateTimeOffset",
+                DateTimeType = "System.DateTimeOffset",
+                TimeType = "System.TimeSpan",
+                TimeSpanType = "System.TimeSpan",
+
+                ArrayType = "System.Collections.Generic.ICollection",
+                DictionaryType = "System.Collections.Generic.IDictionary",
+
+                ArrayBaseType = "System.Collections.Generic.Collection",
+                DictionaryBaseType = "System.Collections.Generic.Dictionary"
             };
 
             CSharpGeneratorSettings.TemplateFactory = new DefaultTemplateFactory(CSharpGeneratorSettings, new[]
@@ -32,8 +46,8 @@ namespace NSwag.CodeGeneration.CSharp
                 typeof(SwaggerToCSharpGeneratorSettings).GetTypeInfo().Assembly,
             });
 
-            ResponseArrayType = "System.Collections.ObjectModel.ObservableCollection";
-            ResponseDictionaryType = "System.Collections.Generic.Dictionary";
+            ResponseArrayType = "System.Collections.Generic.ICollection";
+            ResponseDictionaryType = "System.Collections.Generic.IDictionary";
 
             ParameterArrayType = "System.Collections.Generic.IEnumerable";
             ParameterDictionaryType = "System.Collections.Generic.IDictionary";

--- a/src/NSwag.CodeGeneration.TypeScript/SwaggerToTypeScriptClientGeneratorSettings.cs
+++ b/src/NSwag.CodeGeneration.TypeScript/SwaggerToTypeScriptClientGeneratorSettings.cs
@@ -31,7 +31,8 @@ namespace NSwag.CodeGeneration.TypeScript
             {
                 SchemaType = SchemaType.Swagger2,
                 MarkOptionalProperties = true,
-                TypeNameGenerator = new TypeScriptTypeNameGenerator()
+                TypeNameGenerator = new TypeScriptTypeNameGenerator(),
+                TypeScriptVersion = 2.7m
             };
 
             TypeScriptGeneratorSettings.TemplateFactory = new DefaultTemplateFactory(TypeScriptGeneratorSettings, new Assembly[]
@@ -88,18 +89,17 @@ namespace NSwag.CodeGeneration.TypeScript
 
         // TODO: Angular specific => move
 
-        /// <summary>Gets or sets the HTTP service class (applies only for the Angular template).</summary>
-        public HttpClass HttpClass { get; set; } = HttpClass.Http;
+        /// <summary>Gets or sets the HTTP service class (applies only for the Angular template, default: HttpClient).</summary>
+        public HttpClass HttpClass { get; set; } = HttpClass.HttpClient;
 
-        /// <summary>Gets the RxJs version (Angular template only, default: 5.0).</summary>
-        public decimal RxJsVersion { get; set; } = 5.0m;
+        /// <summary>Gets the RxJs version (Angular template only, default: 6.0).</summary>
+        public decimal RxJsVersion { get; set; } = 6.0m;
 
         /// <summary>Gets a value indicating whether to use the Angular 6 Singleton Provider (Angular template only, default: false).</summary>
         public bool UseSingletonProvider { get; set; } = false;
 
         /// <summary>Gets or sets the injection token type (applies only for the Angular template).</summary>
         public InjectionTokenType InjectionTokenType { get; set; } = InjectionTokenType.OpaqueToken;
-
 
         internal ITemplate CreateTemplate(object model)
         {

--- a/src/NSwag.Commands/Commands/CodeGeneration/SwaggerToCSharpClientCommand.cs
+++ b/src/NSwag.Commands/Commands/CodeGeneration/SwaggerToCSharpClientCommand.cs
@@ -59,7 +59,7 @@ namespace NSwag.Commands.CodeGeneration
             set { Settings.GenerateDtoTypes = value; }
         }
 
-        [Argument(Name = "InjectHttpClient", IsRequired = false, Description = "Specifies whether an HttpClient instance is injected.")]
+        [Argument(Name = "InjectHttpClient", IsRequired = false, Description = "Specifies whether an HttpClient instance is injected (default: true).")]
         public bool InjectHttpClient
         {
             get { return Settings.InjectHttpClient; }

--- a/src/NSwag.Commands/Commands/CodeGeneration/SwaggerToCSharpCommandBase.cs
+++ b/src/NSwag.Commands/Commands/CodeGeneration/SwaggerToCSharpCommandBase.cs
@@ -81,7 +81,7 @@ namespace NSwag.Commands.CodeGeneration
             set { Settings.ParameterArrayType = value; }
         }
 
-        [Argument(Name = "ParameterDictionaryType", IsRequired = false, Description = "The generic dictionary .NET type of operation parameters (default: 'IReadOnlyDictionary').")]
+        [Argument(Name = "ParameterDictionaryType", IsRequired = false, Description = "The generic dictionary .NET type of operation parameters (default: 'IDictionary').")]
         public string ParameterDictionaryType
         {
             get { return Settings.ParameterDictionaryType; }
@@ -147,7 +147,7 @@ namespace NSwag.Commands.CodeGeneration
             set { Settings.CSharpGeneratorSettings.RequiredPropertiesMustBeDefined = value; }
         }
 
-        [Argument(Name = "DateType", IsRequired = false, Description = "The date .NET type (default: 'DateTime').")]
+        [Argument(Name = "DateType", IsRequired = false, Description = "The date .NET type (default: 'DateTimeOffset').")]
         public string DateType
         {
             get { return Settings.CSharpGeneratorSettings.DateType; }
@@ -161,7 +161,7 @@ namespace NSwag.Commands.CodeGeneration
             set { Settings.CSharpGeneratorSettings.JsonConverters = value; }
         }
 
-        [Argument(Name = "DateTimeType", IsRequired = false, Description = "The date time .NET type (default: 'DateTime').")]
+        [Argument(Name = "DateTimeType", IsRequired = false, Description = "The date time .NET type (default: 'DateTimeOffset').")]
         public string DateTimeType
         {
             get { return Settings.CSharpGeneratorSettings.DateTimeType; }
@@ -182,7 +182,7 @@ namespace NSwag.Commands.CodeGeneration
             set { Settings.CSharpGeneratorSettings.TimeSpanType = value; }
         }
 
-        [Argument(Name = "ArrayType", IsRequired = false, Description = "The generic array .NET type (default: 'ObservableCollection').")]
+        [Argument(Name = "ArrayType", IsRequired = false, Description = "The generic array .NET type (default: 'ICollection').")]
         public string ArrayType
         {
             get { return Settings.CSharpGeneratorSettings.ArrayType; }
@@ -196,7 +196,7 @@ namespace NSwag.Commands.CodeGeneration
             set { Settings.CSharpGeneratorSettings.ArrayInstanceType = value; }
         }
 
-        [Argument(Name = "DictionaryType", IsRequired = false, Description = "The generic dictionary .NET type (default: 'Dictionary').")]
+        [Argument(Name = "DictionaryType", IsRequired = false, Description = "The generic dictionary .NET type (default: 'IDictionary').")]
         public string DictionaryType
         {
             get { return Settings.CSharpGeneratorSettings.DictionaryType; }
@@ -210,7 +210,7 @@ namespace NSwag.Commands.CodeGeneration
             set { Settings.CSharpGeneratorSettings.DictionaryInstanceType = value; }
         }
 
-        [Argument(Name = "ArrayBaseType", IsRequired = false, Description = "The generic array .NET type (default: 'ObservableCollection').")]
+        [Argument(Name = "ArrayBaseType", IsRequired = false, Description = "The generic array .NET type (default: 'Collection').")]
         public string ArrayBaseType
         {
             get { return Settings.CSharpGeneratorSettings.ArrayBaseType; }
@@ -224,7 +224,7 @@ namespace NSwag.Commands.CodeGeneration
             set { Settings.CSharpGeneratorSettings.DictionaryBaseType = value; }
         }
 
-        [Argument(Name = "ClassStyle", IsRequired = false, Description = "The CSharp class style, 'Poco' or 'Inpc' (default: 'Inpc').")]
+        [Argument(Name = "ClassStyle", IsRequired = false, Description = "The CSharp class style, 'Poco' or 'Inpc' (default: 'Poco').")]
         public CSharpClassStyle ClassStyle
         {
             get { return Settings.CSharpGeneratorSettings.ClassStyle; }

--- a/src/NSwag.Commands/Commands/CodeGeneration/SwaggerToTypeScriptClientCommand.cs
+++ b/src/NSwag.Commands/Commands/CodeGeneration/SwaggerToTypeScriptClientCommand.cs
@@ -45,7 +45,7 @@ namespace NSwag.Commands.CodeGeneration
             set { Settings.TypeScriptGeneratorSettings.Namespace = value; }
         }
 
-        [Argument(Name = "TypeScriptVersion", IsRequired = false, Description = "The target TypeScript version (default: 1.8).")]
+        [Argument(Name = "TypeScriptVersion", IsRequired = false, Description = "The target TypeScript version (default: 2.7).")]
         public decimal TypeScriptVersion
         {
             get { return Settings.TypeScriptGeneratorSettings.TypeScriptVersion; }
@@ -81,14 +81,14 @@ namespace NSwag.Commands.CodeGeneration
             set { Settings.UseSingletonProvider = value; }
         }
 
-        [Argument(Name = "InjectionTokenType", IsRequired = false, Description = "The Angular injection token type (default 'OpaqueToken', 'InjectionToken').")]
+        [Argument(Name = "InjectionTokenType", IsRequired = false, Description = "The Angular injection token type (default 'InjectionToken', 'OpaqueToken').")]
         public InjectionTokenType InjectionTokenType
         {
             get { return Settings.InjectionTokenType; }
             set { Settings.InjectionTokenType = value; }
         }
 
-        [Argument(Name = "RxJsVersion", IsRequired = false, Description = "The target RxJs version (default: 5.0).")]
+        [Argument(Name = "RxJsVersion", IsRequired = false, Description = "The target RxJs version (default: 6.0).")]
         public decimal RxJsVersion
         {
             get { return Settings.RxJsVersion; }

--- a/src/NSwag.Commands/Commands/SwaggerGeneration/SwaggerGeneratorCommandBase.cs
+++ b/src/NSwag.Commands/Commands/SwaggerGeneration/SwaggerGeneratorCommandBase.cs
@@ -179,7 +179,7 @@ namespace NSwag.Commands.SwaggerGeneration
         [Argument(Name = "Startup", IsRequired = false, Description = "The Startup class type in the form 'assemblyName:fullTypeName' or 'fullTypeName'.")]
         public string StartupType { get; set; }
 
-        [Argument(Name = "AllowNullableBodyParameters", IsRequired = false, Description = "Nullable body parameters are allowed (ignored when MvcOptions.AllowEmptyInputInBodyModelBinding is available, default: true).")]
+        [Argument(Name = "AllowNullableBodyParameters", IsRequired = false, Description = "Nullable body parameters are allowed (ignored when MvcOptions.AllowEmptyInputInBodyModelBinding is available, default: false).")]
         public bool AllowNullableBodyParameters
         {
             get => Settings.AllowNullableBodyParameters;

--- a/src/NSwag.Commands/NSwagDocumentBase.cs
+++ b/src/NSwag.Commands/NSwagDocumentBase.cs
@@ -56,7 +56,7 @@ namespace NSwag.Commands
         public abstract Task<SwaggerDocumentExecutionResult> ExecuteAsync();
 
         /// <summary>Gets or sets the runtime where the document should be processed.</summary>
-        public Runtime Runtime { get; set; }
+        public Runtime Runtime { get; set; } = Runtime.NetCore21;
 
         /// <summary>Gets or sets the default variables.</summary>
         public string DefaultVariables { get; set; }

--- a/src/NSwag.Npm/bin/nswag.js
+++ b/src/NSwag.Npm/bin/nswag.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 "use strict";
 
-var defaultCoreVersion = "11";
+var defaultCoreVersion = "21";
 var supportedCoreVersions = ["10", "11", "20", "21"];
 
 // Initialize
@@ -33,7 +33,7 @@ if (process.env["windir"]) {
 }
 
 var c = require('child_process');
-if (hasFullDotNet && args.toLowerCase().indexOf("/runtime:netcore") == -1) {
+if (hasFullDotNet && args.toLowerCase().indexOf("/runtime:Win") != -1) {
     // Run full .NET version
     if (args.toLowerCase().indexOf("/runtime:winx86") != -1) {
         var cmd = '"' + __dirname + '/binaries/Win/nswag.x86.exe" ' + args;

--- a/src/NSwag.SwaggerGeneration/SwaggerGeneratorSettings.cs
+++ b/src/NSwag.SwaggerGeneration/SwaggerGeneratorSettings.cs
@@ -33,8 +33,8 @@ namespace NSwag.SwaggerGeneration
         /// <summary>Gets or sets the Swagger specification version.</summary>
         public string Version { get; set; } = "1.0.0";
 
-        /// <summary>Gets or sets a value indicating whether nullable body parameters are allowed (ignored when MvcOptions.AllowEmptyInputInBodyModelBinding is available).</summary>
-        public bool AllowNullableBodyParameters { get; set; } = true;
+        /// <summary>Gets or sets a value indicating whether nullable body parameters are allowed (ignored when MvcOptions.AllowEmptyInputInBodyModelBinding is available, default: false).</summary>
+        public bool AllowNullableBodyParameters { get; set; } = false;
 
         /// <summary>Gets the operation processor.</summary>
         [JsonIgnore]


### PR DESCRIPTION
Change setting defaults. 

**Remarks:** 

- When using an nswag.json file, the old settings are retained and this is not a breaking change. 
- When using the CLI directly (e.g. swagger2csharp) then these defaults **may be a breaking change**

Command line/NSwagStudio: 

- [x] **Change default **runtime** to /runtime:NetCore20 or 2.1** (before: WinX64)

Swagger generator: 

- [x] Change default of **AllowNullableBodyParameters** to false **(breaking change)**
- [ ] ~~Change default of AllowReferencesWithProperties to true?~~

TypeScript generator: 

- [x] Change default of **TypeScriptVersion** to a reasonable value (2.7)
- [x] Set default of SwaggerToTypeScriptClientGeneratorSettings.**HttpClass** to `HttpClient` also RxJs to 6.0
- [x] Set default of SwaggerToTypeScriptClientGeneratorSettings.**InjectionTokenType** to `InjectionToken`

CSharp generator: 

- [x] Set default of SwaggerToCSharpClientGeneratorSettings.**InjectHttpClient** to `true`
- [x] Use **ClassStyle** POCO instead of INPC for C# DTOs
- [x] New default C# generator type settings: 

```csharp
// Client/Controller parameter/response types

ResponseArrayType = "System.Collections.Generic.ICollection";
ResponseDictionaryType = "System.Collections.Generic.IDictionary";

ParameterArrayType = "System.Collections.Generic.IEnumerable";
ParameterDictionaryType = "System.Collections.Generic.IDictionary";

// DTO Properties

DateType = "System.DateTimeOffset";
DateTimeType = "System.DateTimeOffset";
TimeType = "System.TimeSpan";
TimeSpanType = "System.TimeSpan";

ArrayType = "System.Collections.Generic.ICollection";
DictionaryType = "System.Collections.Generic.IDictionary";

// DTO base types
ArrayBaseType = "System.Collections.Generic.Collection";
DictionaryBaseType = "System.Collections.Generic.Dictionary";
```

Move default settings to NJS: https://github.com/RSuter/NJsonSchema/pull/806