### PR TITLE
Fix for .net core 2.2 support in npm package

### DIFF
--- a/src/NSwag.Npm/bin/nswag.js
+++ b/src/NSwag.Npm/bin/nswag.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 "use strict";
 
-var defaultCoreVersion = "21";
-var supportedCoreVersions = ["10", "11", "20", "21"];
+var defaultCoreVersion = "22";
+var supportedCoreVersions = ["10", "11", "20", "21", "22"];
 
 // Initialize
 process.title = 'nswag';


### PR DESCRIPTION
Adding .net core 2.2 as default runtime
Adding 22 to supportedCoreVersions array