### PR TITLE
Remove unnecessary comment for pragma warning disable

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/File.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/File.liquid
@@ -10,7 +10,7 @@ using {{ usage }};
 
 namespace {{ Namespace }}
 {
-    #pragma warning disable // Disable all warnings
+    #pragma warning disable
 
     {{ Clients | tab }}
 


### PR DESCRIPTION
Incompatible with Resharper code analysis