### PR TITLE
Path param with model binder attribute

### DIFF
--- a/src/NSwag.SwaggerGeneration.AspNetCore.Tests.Web/Controllers/Parameters/PathParameterWithModelBinderController.cs
+++ b/src/NSwag.SwaggerGeneration.AspNetCore.Tests.Web/Controllers/Parameters/PathParameterWithModelBinderController.cs
@@ -1,0 +1,29 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace NSwag.SwaggerGeneration.AspNetCore.Tests.Web.Controllers.Parameters
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class PathParameterWithModelBinderController : Controller
+    {
+        [HttpGet("{stringModel}")]
+        public ActionResult RequiredRouteParamWithModelBinder([ModelBinder(typeof(StringModelBinder))] string stringModel)
+        {
+            return Ok();
+        }
+
+        public class StringModelBinder : IModelBinder
+        {
+            public Task BindModelAsync(ModelBindingContext bindingContext)
+            {
+                bindingContext.Result =
+                    ModelBindingResult.Success(
+                        bindingContext.ValueProvider.GetValue(
+                            bindingContext.ModelName));
+                return Task.CompletedTask;
+            }
+        }
+    }
+}

--- a/src/NSwag.SwaggerGeneration.AspNetCore.Tests/Parameters/PathParameterWithModelBinderTests.cs
+++ b/src/NSwag.SwaggerGeneration.AspNetCore.Tests/Parameters/PathParameterWithModelBinderTests.cs
@@ -1,0 +1,24 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using NSwag.SwaggerGeneration.AspNetCore.Tests.Web.Controllers.Parameters;
+using Xunit;
+
+namespace NSwag.SwaggerGeneration.AspNetCore.Tests.Parameters
+{
+    public class PathParameterWithModelBinderTests : AspNetCoreTestsBase
+    {
+        [Fact]
+        public async Task When_model_binder_parameter_is_used_on_path_parameter_then_parameter_kind_is_path()
+        {
+            // Arrange
+            var settings = new AspNetCoreToSwaggerGeneratorSettings { RequireParametersWithoutDefault = true };
+
+            // Act
+            var document = await GenerateDocumentAsync(settings, typeof(PathParameterWithModelBinderController));
+
+            // Assert
+            var kind = document.Operations.First().Operation.Parameters.First().Kind;
+            Assert.Equal(SwaggerParameterKind.Path, kind);
+        }
+    }
+}

--- a/src/NSwag.SwaggerGeneration.AspNetCore/Processors/OperationParameterProcessor.cs
+++ b/src/NSwag.SwaggerGeneration.AspNetCore/Processors/OperationParameterProcessor.cs
@@ -129,8 +129,8 @@ namespace NSwag.SwaggerGeneration.AspNetCore.Processors
 
                 SwaggerParameter operationParameter = null;
                 if (apiParameter.Source == BindingSource.Path ||
-                    apiParameter.Source == BindingSource.Custom &&
-                    httpPath.Contains($"{{{apiParameter.Name}}}"))
+                    (apiParameter.Source == BindingSource.Custom &&
+                     httpPath.Contains($"{{{apiParameter.Name}}}")))
                 {
                     operationParameter = await CreatePrimitiveParameterAsync(context, extendedApiParameter).ConfigureAwait(false);
                     operationParameter.Kind = SwaggerParameterKind.Path;

--- a/src/NSwag.SwaggerGeneration.AspNetCore/Processors/OperationParameterProcessor.cs
+++ b/src/NSwag.SwaggerGeneration.AspNetCore/Processors/OperationParameterProcessor.cs
@@ -128,7 +128,9 @@ namespace NSwag.SwaggerGeneration.AspNetCore.Processors
                 }
 
                 SwaggerParameter operationParameter = null;
-                if (apiParameter.Source == BindingSource.Path)
+                if (apiParameter.Source == BindingSource.Path ||
+                    apiParameter.Source == BindingSource.Custom &&
+                    httpPath.Contains($"{{{apiParameter.Name}}}"))
                 {
                     operationParameter = await CreatePrimitiveParameterAsync(context, extendedApiParameter).ConfigureAwait(false);
                     operationParameter.Kind = SwaggerParameterKind.Path;


### PR DESCRIPTION
When using a `ModelBinderAttribute` on a path parameter, the api explorer sets the `BindingSource` to `Custom` which leads to it appearing as a query parameter in the swagger documentation, even though it is properly treated as a path parameter by asp. A workaround is to also add the `[FromRoute]` tag, but this PR adds a small check to detect when a parameter has a custom binding source but is actually coming from the path to avoid having to use this workaround.

I also added a test for it to highlight the issue. 