### PR TITLE
Generate Authorization attributes in controller.

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Models/CSharpControllerTemplateModel.cs
+++ b/src/NSwag.CodeGeneration.CSharp/Models/CSharpControllerTemplateModel.cs
@@ -85,5 +85,35 @@ namespace NSwag.CodeGeneration.CSharp.Models
 
         /// <summary>Gets the API version.</summary>
         public string Version => _document.Info.Version;
-    }
+
+		/// <summary>Gets the setting which indicates if authorization attributes should be generated.</summary>
+		public bool GenerateAuthorizationAttributes => _settings.GenerateAuthorizationAttributes;
+
+		/// <summary>Checks if any authentication scheme are mapped to this controller.</summary>
+		public bool HasSecurity { get { return GetHasSecurity(); } }
+
+		/// <summary>Gets a comma delimited list of authentication scheme names mapped to this controller.</summary>
+		public string AuthenticationSchemes { get { return GetAuthenticationSchemes(); } }
+
+		private bool GetHasSecurity()
+		{
+			return (_document.Security.Count > 0);
+		}
+
+		private string GetAuthenticationSchemes()
+		{
+			string authenticationSchemes = "";
+
+			foreach (Dictionary<string, IEnumerable<string>> authenticationSchemeDictionary in _document.Security)
+			{
+				foreach (KeyValuePair<string, IEnumerable<string>> authenticationScheme in authenticationSchemeDictionary)
+				{
+					authenticationSchemes += (string.IsNullOrWhiteSpace(authenticationSchemes)) ? "" : ",";
+					authenticationSchemes += authenticationScheme.Key;
+				}
+			}
+
+			return authenticationSchemes;
+		}
+	}
 }

--- a/src/NSwag.CodeGeneration.CSharp/Models/CSharpOperationModel.cs
+++ b/src/NSwag.CodeGeneration.CSharp/Models/CSharpOperationModel.cs
@@ -77,6 +77,8 @@ namespace NSwag.CodeGeneration.CSharp.Models
                     _generator,
                     _resolver))
                 .ToList();
+
+			Security = operation.Security.Select(scheme => scheme as Dictionary<string, IEnumerable<string>>).ToList();
         }
 
         /// <summary>Gets the method's access modifier.</summary>
@@ -198,6 +200,15 @@ namespace NSwag.CodeGeneration.CSharp.Models
             }
         }
 
+		/// <summary>Gets the security schemes mapped to this operation.</summary>
+		public List<Dictionary<string, IEnumerable<string>>> Security { get; private set; }
+
+		/// <summary>Checks if any authentication scheme are mapped to this operation.</summary>
+		public bool HasSecurity { get { return GetHasSecurity(); } }
+
+		/// <summary>Gets a comma delimited list of authentication scheme names mapped to this operation.</summary>
+		public string AuthenticationSchemes { get { return GetAuthenticationSchemes(); } }
+
         /// <summary>Gets the name of the parameter variable.</summary>
         /// <param name="parameter">The parameter.</param>
         /// <param name="allParameters">All parameters.</param>
@@ -245,5 +256,26 @@ namespace NSwag.CodeGeneration.CSharp.Models
         {
             return new CSharpResponseModel(this, operation, statusCode, response, response == GetSuccessResponse().Value, exceptionSchema, generator, resolver, settings.CodeGeneratorSettings);
         }
+
+		private bool GetHasSecurity()
+		{
+			return (Security.Count > 0);
+		}
+
+		private string GetAuthenticationSchemes()
+		{
+			string authenticationSchemes = "";
+
+			foreach (Dictionary<string, IEnumerable<string>> authenticationSchemeDictionary in Security)
+			{
+				foreach (KeyValuePair<string, IEnumerable<string>> authenticationScheme in authenticationSchemeDictionary)
+				{
+					authenticationSchemes += (string.IsNullOrWhiteSpace(authenticationSchemes)) ? "" : ",";
+					authenticationSchemes += authenticationScheme.Key;
+				}
+			}
+
+			return authenticationSchemes;
+		}
     }
 }

--- a/src/NSwag.CodeGeneration.CSharp/SwaggerToCSharpControllerGeneratorSettings.cs
+++ b/src/NSwag.CodeGeneration.CSharp/SwaggerToCSharpControllerGeneratorSettings.cs
@@ -53,5 +53,8 @@ namespace NSwag.CodeGeneration.CSharp
 
         /// <summary>Gets or sets the strategy for naming routes (default: CSharpRouteNamingStrategy.None).</summary>
         public CSharpControllerRouteNamingStrategy RouteNamingStrategy { get; set; }
-    }
+
+		/// <summary>Controls the generation of Authorization attributes if security schemes are specified (default: false).</summary>
+		public bool GenerateAuthorizationAttributes { get; set; }
+	}
 }

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Controller.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Controller.liquid
@@ -53,6 +53,9 @@ public partial class {{ Class }}Controller : {% if HasBaseClass %}{{ BaseClass }
     [System.Obsolete]
 {%         endif -%}
     [{{ AspNetNamespace }}.Http{{ operation.HttpMethodUpper }}, {{ AspNetNamespace }}.Route("{{ operation.Path }}"{% if operation.HasRouteName %}, Name = "{{ operation.RouteName }}"{% endif %})]
+{%         if operation.HasSecurity -%}
+    [Microsoft.AspNetCore.Authorization.Authorize(AuthenticationSchemes = "{{ operation.AuthenticationSchemes }}")]
+{%         endif -%}
     public {% if operation.WrapResponse %}async System.Threading.Tasks.Task<HttpResponseMessage>{% else %}{{ operation.ResultType }}{% endif %} {{ operation.ActualOperationName }}({% for parameter in operation.Parameters %}{% if parameter.IsBody %}[{{ AspNetNamespace }}.FromBody] {% endif %}{{ parameter.Type }} {{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %} = null{% endif %}{% if parameter.IsLast == false or UseCancellationToken %}, {% endif %}{% endfor %}{% if UseCancellationToken %}System.Threading.CancellationToken cancellationToken{% endif %})
     {
 {%         if operation.WrapResponse -%}

--- a/src/NSwag.CodeGeneration.CSharp/Templates/Controller.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Controller.liquid
@@ -28,6 +28,9 @@ public interface I{{ Class }}Controller
 [{{ AspNetNamespace }}.RoutePrefix("{{ BasePath }}")]
 {% endif -%}
 {% if GeneratePartialControllers -%}
+{%     if GenerateAuthorizationAttributes and HasSecurity -%}
+[Microsoft.AspNetCore.Authorization.Authorize(AuthenticationSchemes = "{{ AuthenticationSchemes }}")]
+{%     endif -%}
 public partial class {{ Class }}Controller : {% if HasBaseClass %}{{ BaseClass }}{% else %}{{ AspNetNamespace }}.ApiController{% endif %}
 {
     private I{{ Class }}Controller _implementation;
@@ -53,7 +56,7 @@ public partial class {{ Class }}Controller : {% if HasBaseClass %}{{ BaseClass }
     [System.Obsolete]
 {%         endif -%}
     [{{ AspNetNamespace }}.Http{{ operation.HttpMethodUpper }}, {{ AspNetNamespace }}.Route("{{ operation.Path }}"{% if operation.HasRouteName %}, Name = "{{ operation.RouteName }}"{% endif %})]
-{%         if operation.HasSecurity -%}
+{%         if GenerateAuthorizationAttributes and operation.HasSecurity -%}
     [Microsoft.AspNetCore.Authorization.Authorize(AuthenticationSchemes = "{{ operation.AuthenticationSchemes }}")]
 {%         endif -%}
     public {% if operation.WrapResponse %}async System.Threading.Tasks.Task<HttpResponseMessage>{% else %}{{ operation.ResultType }}{% endif %} {{ operation.ActualOperationName }}({% for parameter in operation.Parameters %}{% if parameter.IsBody %}[{{ AspNetNamespace }}.FromBody] {% endif %}{{ parameter.Type }} {{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %} = null{% endif %}{% if parameter.IsLast == false or UseCancellationToken %}, {% endif %}{% endfor %}{% if UseCancellationToken %}System.Threading.CancellationToken cancellationToken{% endif %})


### PR DESCRIPTION
Hi,
I need Authorization attributes to be generated in the Controller.liquid template, if specified in the swagger definition. This pull request indicates a way that this might work. It only caters for operation level security scheme mappings, in ASP Net Core, for api key and basic schemes types.

A complete solution would probably require support for ASP Net, for controller level security mappings, and for OAuth2 and OpenID Connect schemes types, and also be guarded by an opt-in setting.

Can it work this way, or do you see this developing in some other direction, in NSwag.CodeGeneration.CSharp?