### PR TITLE
Add support for custom CSS and JavaScript in the Swagger UI

### DIFF
--- a/src/NSwag.AspNetCore/SwaggerUi/index.html
+++ b/src/NSwag.AspNetCore/SwaggerUi/index.html
@@ -11,6 +11,7 @@
   <link href='css/screen.css' media='screen' rel='stylesheet' type='text/css'/>
   <link href='css/reset.css' media='print' rel='stylesheet' type='text/css'/>
   <link href='css/print.css' media='print' rel='stylesheet' type='text/css'/>
+  <link href='{StylesheetUri}' media='screen' rel='stylesheet' type='text/css'/>
 
   <script src='lib/object-assign-pollyfill.js' type='text/javascript'></script>
   <script src='lib/jquery-1.8.0.min.js' type='text/javascript'></script>
@@ -89,6 +90,7 @@
       }
   });
   </script>
+  <script src="{ScriptUri}"> </script>
 </head>
 
 <body class="swagger-section">

--- a/src/NSwag.AspNetCore/SwaggerUi3/index.html
+++ b/src/NSwag.AspNetCore/SwaggerUi3/index.html
@@ -28,6 +28,7 @@
         background: #fafafa;
       }
     </style>
+    <link rel="stylesheet" type="text/css" href="{StylesheetUri}" >
   </head>
 
   <body>
@@ -98,7 +99,8 @@ window.onload = function() {
   }
 
   window.ui = ui;
-}  
+}
     </script>
+    <script src="{ScriptUri}"> </script>
   </body>
 </html>

--- a/src/NSwag.AspNetCore/SwaggerUi3Settings.cs
+++ b/src/NSwag.AspNetCore/SwaggerUi3Settings.cs
@@ -89,6 +89,8 @@ namespace NSwag.AspNetCore
             html = html.Replace("{RedirectUrl}", string.IsNullOrEmpty(ServerUrl) ?
                 "window.location.origin + \"" + TransformToExternalPath(Path, request) + "/oauth2-redirect.html\"" :
                 "\"" + ServerUrl + TransformToExternalPath(Path, request) + "/oauth2-redirect.html\"");
+            html = html.Replace("{StylesheetUri}", CustomStylesheetUri?.ToString() ?? "");
+            html = html.Replace("{ScriptUri}", CustomJavaScriptUri?.ToString() ?? "");
 
             return html;
         }

--- a/src/NSwag.AspNetCore/SwaggerUiSettings.cs
+++ b/src/NSwag.AspNetCore/SwaggerUiSettings.cs
@@ -65,6 +65,8 @@ namespace NSwag.AspNetCore
             html = html.Replace("{UseJsonEditor}", UseJsonEditor ? "true" : "false");
             html = html.Replace("{DefaultModelRendering}", DefaultModelRendering);
             html = html.Replace("{ShowRequestHeaders}", ShowRequestHeaders ? "true" : "false");
+            html = html.Replace("{StylesheetUri}", CustomStylesheetUri?.ToString() ?? "");
+            html = html.Replace("{ScriptUri}", CustomJavaScriptUri?.ToString() ?? "");
 
             return html;
         }

--- a/src/NSwag.AspNetCore/SwaggerUiSettingsBase.cs
+++ b/src/NSwag.AspNetCore/SwaggerUiSettingsBase.cs
@@ -33,6 +33,12 @@ namespace NSwag.AspNetCore
 
         internal string ActualSwaggerUiPath => Path.Substring(MiddlewareBasePath?.Length ?? 0);
 
+        /// <summary>Gets or sets a URI to load a custom CSS Stylesheet into the index.html</summary>
+        public Uri CustomStylesheetUri { get; set; }
+
+        /// <summary>Gets or sets a URI to load a custom JavaScript file into the index.html.</summary>
+        public Uri CustomJavaScriptUri { get; set; }
+
         /// <summary>Gets or sets the external route base path (must start with '/', default: null = use SwaggerUiRoute).</summary>
 #if AspNetOwin
         public Func<string, IOwinRequest, string> TransformToExternalPath { get; set; }


### PR DESCRIPTION
Allows users to add a URI to load a custom CSS stylesheet and a URI to load a custom JavaScript file into the Swagger index.html.

Resolves #1137 