### PR TITLE
Prevent empty link and script tags when custom CSS or custom JS not s…

### DIFF
--- a/src/NSwag.AspNetCore/SwaggerUi/index.html
+++ b/src/NSwag.AspNetCore/SwaggerUi/index.html
@@ -11,8 +11,7 @@
   <link href='css/screen.css' media='screen' rel='stylesheet' type='text/css'/>
   <link href='css/reset.css' media='print' rel='stylesheet' type='text/css'/>
   <link href='css/print.css' media='print' rel='stylesheet' type='text/css'/>
-  <link href='{StylesheetUri}' media='screen' rel='stylesheet' type='text/css'/>
-
+  {CustomStyle}
   <script src='lib/object-assign-pollyfill.js' type='text/javascript'></script>
   <script src='lib/jquery-1.8.0.min.js' type='text/javascript'></script>
   <script src='lib/jquery.slideto.min.js' type='text/javascript'></script>
@@ -90,7 +89,7 @@
       }
   });
   </script>
-  <script src="{ScriptUri}"> </script>
+  {CustomScript}
 </head>
 
 <body class="swagger-section">

--- a/src/NSwag.AspNetCore/SwaggerUi3/index.html
+++ b/src/NSwag.AspNetCore/SwaggerUi3/index.html
@@ -28,7 +28,7 @@
         background: #fafafa;
       }
     </style>
-    <link rel="stylesheet" type="text/css" href="{StylesheetUri}" >
+    {CustomStyle}
   </head>
 
   <body>
@@ -101,6 +101,6 @@ window.onload = function() {
   window.ui = ui;
 }
     </script>
-    <script src="{ScriptUri}"> </script>
+    {CustomScript}
   </body>
 </html>

--- a/src/NSwag.AspNetCore/SwaggerUi3Settings.cs
+++ b/src/NSwag.AspNetCore/SwaggerUi3Settings.cs
@@ -89,8 +89,8 @@ namespace NSwag.AspNetCore
             html = html.Replace("{RedirectUrl}", string.IsNullOrEmpty(ServerUrl) ?
                 "window.location.origin + \"" + TransformToExternalPath(Path, request) + "/oauth2-redirect.html\"" :
                 "\"" + ServerUrl + TransformToExternalPath(Path, request) + "/oauth2-redirect.html\"");
-            html = html.Replace("{StylesheetUri}", CustomStylesheetUri?.ToString() ?? "");
-            html = html.Replace("{ScriptUri}", CustomJavaScriptUri?.ToString() ?? "");
+            html = html.Replace("{CustomStyle}", GetCustomStyleHtml());
+            html = html.Replace("{CustomScript}", GetCustomScriptHtml());
 
             return html;
         }

--- a/src/NSwag.AspNetCore/SwaggerUiSettings.cs
+++ b/src/NSwag.AspNetCore/SwaggerUiSettings.cs
@@ -65,8 +65,8 @@ namespace NSwag.AspNetCore
             html = html.Replace("{UseJsonEditor}", UseJsonEditor ? "true" : "false");
             html = html.Replace("{DefaultModelRendering}", DefaultModelRendering);
             html = html.Replace("{ShowRequestHeaders}", ShowRequestHeaders ? "true" : "false");
-            html = html.Replace("{StylesheetUri}", CustomStylesheetUri?.ToString() ?? "");
-            html = html.Replace("{ScriptUri}", CustomJavaScriptUri?.ToString() ?? "");
+            html = html.Replace("{CustomStyle}", GetCustomStyleHtml());
+            html = html.Replace("{CustomScript}", GetCustomScriptHtml());
 
             return html;
         }

--- a/src/NSwag.AspNetCore/SwaggerUiSettingsBase.cs
+++ b/src/NSwag.AspNetCore/SwaggerUiSettingsBase.cs
@@ -49,5 +49,35 @@ namespace NSwag.AspNetCore
 
         internal abstract string TransformHtml(string html, HttpRequest request);
 #endif
+
+        /// <summary>
+        /// Gets an HTML snippet for including custom StyleSheet in swagger UI.
+        /// </summary>
+        protected string GetCustomStyleHtml()
+        {
+            if (CustomStylesheetUri == null)
+            {
+                return string.Empty;
+            }
+
+            var uriString = System.Net.WebUtility.HtmlEncode(CustomStylesheetUri.OriginalString);
+
+            return $"<link rel=\"stylesheet\" href=\"{uriString}\">";
+        }
+
+        /// <summary>
+        /// Gets an HTML snippet for including custom JavaScript in swagger UI.
+        /// </summary>
+        protected string GetCustomScriptHtml()
+        {
+            if (CustomJavaScriptUri == null)
+            {
+                return string.Empty;
+            }
+            
+            var uriString = System.Net.WebUtility.HtmlEncode(CustomJavaScriptUri.OriginalString);
+
+            return $"<script src=\"{uriString}\"></script>";
+        }
     }
 }


### PR DESCRIPTION
Prevent invalid empty `<link>` or `<script>` tags being present in swagger HTML when `CustomStylesheetUri` or `CustomJavaScriptUri` properties are not populated.

Additionally, HTML encode URLs when included in page.