### PR TITLE
#1776 Omit brackets in operation names

### DIFF
--- a/src/NSwag.CodeGeneration.Tests/CodeGenerationTests.cs
+++ b/src/NSwag.CodeGeneration.Tests/CodeGenerationTests.cs
@@ -5,6 +5,7 @@ using NJsonSchema;
 using NJsonSchema.CodeGeneration.TypeScript;
 using NJsonSchema.Generation;
 using NSwag.CodeGeneration.CSharp;
+using NSwag.CodeGeneration.OperationNameGenerators;
 using NSwag.CodeGeneration.TypeScript;
 using Xunit;
 
@@ -93,6 +94,21 @@ namespace NSwag.CodeGeneration.Tests
 
             //// Assert
             var jsonService = document.ToJson(); // no exception expected
+        }
+
+        [Fact]
+        public void No_Brackets_in_Operation_Name() 
+        {
+            // Arrange
+            var path = "/my/path/with/{parameter_with_underscore}/and/{another_parameter}";
+
+            //// Act
+            var operationName = SingleClientFromPathSegmentsOperationNameGenerator.ConvertPathToName(path);
+
+            // Assert
+            Assert.DoesNotContain("{", operationName);
+            Assert.DoesNotContain("}", operationName);
+            Assert.False(string.IsNullOrWhiteSpace(operationName));
         }
 
         private static async Task<SwaggerDocument> CreateDocumentAsync()

--- a/src/NSwag.CodeGeneration/OperationNameGenerators/SingleClientFromPathSegmentsOperationNameGenerator.cs
+++ b/src/NSwag.CodeGeneration/OperationNameGenerators/SingleClientFromPathSegmentsOperationNameGenerator.cs
@@ -7,6 +7,7 @@
 //-----------------------------------------------------------------------
 
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace NSwag.CodeGeneration.OperationNameGenerators
 {
@@ -55,9 +56,9 @@ namespace NSwag.CodeGeneration.OperationNameGenerators
         /// <summary>Converts the path to an operation name.</summary>
         /// <param name="path">The HTTP path.</param>
         /// <returns>The operation name.</returns>
-        internal static string ConvertPathToName(string path)
+        public static string ConvertPathToName(string path)
         {
-            var name = path
+            var name = Regex.Replace(path, @"\{.*?\}", "")
                 .Split('/', '-', '_')
                 .Where(part => !part.Contains("{") && !string.IsNullOrWhiteSpace(part))
                 .Aggregate("", (current, part) => current + CapitalizeFirst(part));


### PR DESCRIPTION
ConvertPathToName checked, if a path segment contains "{", but if the
parameters enclosed in those brackets includes underscores, the
resulting operation name included "}", which is an illegal character in
operation names for most languages.
The new introduced regex eliminates parameters from the path before
creating the operation name. A test has been added to check that it is
working.