### PR TITLE
Generate additional namespace usages from the swagger definitions

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Models/CSharpFileTemplateModel.cs
+++ b/src/NSwag.CodeGeneration.CSharp/Models/CSharpFileTemplateModel.cs
@@ -51,11 +51,6 @@ namespace NSwag.CodeGeneration.CSharp.Models
         /// <summary>Gets the namespace.</summary>
         public string Namespace => _settings.CSharpGeneratorSettings.Namespace ?? string.Empty;
 
-        /// <summary>Gets the all the namespace usages.</summary>
-        public string[] NamespaceUsages => (_outputType == ClientGeneratorOutputType.Contracts ?
-            _settings.AdditionalContractNamespaceUsages?.Where(n => n != null).ToArray() :
-            _settings.AdditionalNamespaceUsages?.Where(n => n != null).ToArray()) ?? new string[] { };
-
         /// <summary>Gets a value indicating whether to generate contract code.</summary>
         public bool GenerateContracts =>
             _outputType == ClientGeneratorOutputType.Full ||
@@ -103,6 +98,30 @@ namespace NSwag.CodeGeneration.CSharp.Models
 
         /// <summary>Gets or sets a value indicating whether to generate the response class (only applied when WrapResponses == true, default: true).</summary>
         public bool GenerateResponseClasses => _settings.GenerateResponseClasses;
+
+        /// <summary>Gets all the namespace usages.</summary>
+        public string[] NamespaceUsages
+        {
+            get
+            {
+                var namespaceUsages = (_outputType == ClientGeneratorOutputType.Contracts ?
+                    _settings.AdditionalContractNamespaceUsages?.Where(n => n != null).ToArray() :
+                    _settings.AdditionalNamespaceUsages?.Where(n => n != null).ToArray()) ?? new string[] { };
+                
+                if (_settings.GenerateAdditionalNamespaceUsagesFromSwaggerDefinitions)
+                {
+                    return _document.Definitions.Keys
+                        .Where(k => k.Contains('.'))
+                        .Select(k => k.Remove(k.LastIndexOf('.')))
+                        .Where(k => !string.IsNullOrWhiteSpace(k))
+                        .Concat(namespaceUsages)
+                        .Distinct()
+                        .ToArray();
+                }
+
+                return namespaceUsages;
+            }
+        }
 
         /// <summary>Gets the response class names.</summary>
         public IEnumerable<string> ResponseClassNames

--- a/src/NSwag.CodeGeneration.CSharp/SwaggerToCSharpGeneratorSettings.cs
+++ b/src/NSwag.CodeGeneration.CSharp/SwaggerToCSharpGeneratorSettings.cs
@@ -68,6 +68,9 @@ namespace NSwag.CodeGeneration.CSharp
         /// <summary>Gets or sets the additional namespace usages.</summary>
         public string[] AdditionalNamespaceUsages { get; set; }
 
+        /// <summary>Gets or sets a value indicating whether to generate additional namespaces usages from the swagger definitions (default: false).</summary>
+        public bool GenerateAdditionalNamespaceUsagesFromSwaggerDefinitions { get; set; }
+
         /// <summary>Gets or sets the additional contract namespace usages.</summary>
         public string[] AdditionalContractNamespaceUsages { get; set; }
 

--- a/src/NSwag.Commands/Commands/CodeGeneration/SwaggerToCSharpClientCommand.cs
+++ b/src/NSwag.Commands/Commands/CodeGeneration/SwaggerToCSharpClientCommand.cs
@@ -169,6 +169,14 @@ namespace NSwag.Commands.CodeGeneration
             set { Settings.CSharpGeneratorSettings.TypeAccessModifier = value; }
         }
 
+        [Argument(Name = "GenerateAdditionalNamespaceUsagesFromSwaggerDefinitions", IsRequired = false,
+                  Description = "Specifies whether to generate additional namespaces usages from the swagger definitions.")]
+        public bool GenerateAdditionalNamespaceUsagesFromSwaggerDefinitions
+        {
+            get { return Settings.GenerateAdditionalNamespaceUsagesFromSwaggerDefinitions; }
+            set { Settings.GenerateAdditionalNamespaceUsagesFromSwaggerDefinitions = value; }
+        }
+
         [Argument(Name = "GenerateContractsOutput", IsRequired = false,
                   Description = "Specifies whether to generate contracts output (interface and models in a separate file set with the ContractsOutput parameter).")]
         public bool GenerateContractsOutput { get; set; }

--- a/src/NSwagStudio/Views/CodeGenerators/SwaggerToCSharpClientGeneratorView.xaml
+++ b/src/NSwagStudio/Views/CodeGenerators/SwaggerToCSharpClientGeneratorView.xaml
@@ -44,6 +44,11 @@
                              ToolTip="AdditionalNamespaceUsages" 
                              Margin="0,0,0,12" />
 
+                    <CheckBox IsChecked="{Binding Command.GenerateAdditionalNamespaceUsagesFromSwaggerDefinitions, Mode=TwoWay}" 
+                              ToolTip="GenerateAdditionalNamespaceUsagesFromSwaggerDefinitions"
+                              Content="Generate additional namespaces usages from the swagger definitions" 
+                              Margin="0,0,0,12" />
+                    
                     <CheckBox IsChecked="{Binding Command.GenerateContractsOutput, Mode=TwoWay}" 
                               ToolTip="GenerateContractsOutput"
                               Content="Generate contracts output" 
@@ -109,7 +114,7 @@
                                 <CheckBox IsChecked="{Binding Command.UseBaseUrl, Mode=TwoWay}" 
                                           Content="Use the base URL for the request" 
                                           ToolTip="UseBaseUrl" Margin="0,0,0,12" />
-                                
+
                                 <CheckBox IsChecked="{Binding Command.GenerateBaseUrlProperty, Mode=TwoWay}" 
                                           Visibility="{Binding Command.UseBaseUrl, Converter={StaticResource VisibilityConverter}}"
                                           Content="Generate the BaseUrl property (must be defined on the base class otherwise)" 


### PR DESCRIPTION
Adds an option to generate additional namespace usages from the swagger definitions

Background:
My service and client projects both have dependencies on libraries that contain DTOs.
My swagger.json contains the namespaces in the definitions but there's currently no way to utilize those in NSwag (as far as I know).
These changes allow add an option to NSwag to generate namespace usages for DTOs directly from the swagger definitions (given that they're already included in the swagger.json, otherwise the option does nothing).