### PR TITLE
Generate distinct variables if the names contains special characters

### DIFF
--- a/src/NSwag.CodeGeneration/DefaultParameterNameGenerator.cs
+++ b/src/NSwag.CodeGeneration/DefaultParameterNameGenerator.cs
@@ -15,6 +15,8 @@ namespace NSwag.CodeGeneration
     /// <summary>The default parameter name generator.</summary>
     public class DefaultParameterNameGenerator : IParameterNameGenerator
     {
+        private readonly Dictionary<string, short> _knowParameters = new Dictionary<string, short>();
+
         /// <summary>Generates the parameter name for the given parameter.</summary>
         /// <param name="parameter">The parameter.</param>
         /// <param name="allParameters">All parameters.</param>
@@ -34,7 +36,13 @@ namespace NSwag.CodeGeneration
                 .Replace("]", string.Empty), true);
 
             if (allParameters.Count(p => p.Name == parameter.Name) > 1)
-                return variableName + parameter.Kind;
+                variableName = variableName + parameter.Kind;
+
+            var key = $"{parameter.ParentOperation?.OperationId}.{variableName}";
+            if (!_knowParameters.ContainsKey(key))
+                _knowParameters.Add(key, 1);
+            else
+                variableName = $"{variableName}{_knowParameters[key]++}";
 
             return variableName;
         }

--- a/src/NSwag.Core/SwaggerParameter.cs
+++ b/src/NSwag.Core/SwaggerParameter.cs
@@ -26,8 +26,11 @@ namespace NSwag
         private bool _explode;
         private int? _position;
 
+        /// <summary>
+        /// Parent Operation
+        /// </summary>
         [JsonIgnore]
-        internal SwaggerOperation ParentOperation => Parent as SwaggerOperation;
+        public SwaggerOperation ParentOperation => Parent as SwaggerOperation;
 
         /// <summary>Gets or sets the name.</summary>
         [JsonProperty(PropertyName = "name", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
@@ -195,12 +198,12 @@ namespace NSwag
         /// <summary>Gets a value indicating whether this is an XML body parameter.</summary>
         [JsonIgnore]
         public bool IsXmlBodyParameter => Kind == SwaggerParameterKind.Body &&
-                                          (Parent as SwaggerOperation)?.ActualConsumes?.FirstOrDefault() == "application/xml" &&
+                                          ParentOperation?.ActualConsumes?.FirstOrDefault() == "application/xml" &&
                                           ((SwaggerOperation)Parent).ActualConsumes?.Contains("application/json") != true;
 
         /// <summary>Gets a value indicating whether this is an binary body parameter.</summary>
         [JsonIgnore]
         public bool IsBinaryBodyParameter => Kind == SwaggerParameterKind.Body &&
-                                             (Parent as SwaggerOperation)?.ActualConsumes?.FirstOrDefault() == "application/octet-stream";
+                                             ParentOperation?.ActualConsumes?.FirstOrDefault() == "application/octet-stream";
     }
 }


### PR DESCRIPTION
In some cases, the generated name of several variables are the same.
In my case, the api provide a parameter $limit and a parameter limit, and both generate a variable limit.