### PR TITLE
Don't call UpdateJsonSerializerSettings in csharp template if not present

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -36,7 +36,9 @@
 {% if SerializeTypeInformation -%}
             settings.TypeNameHandling = Newtonsoft.Json.TypeNameHandling.Auto;
 {% endif -%}
+{% if GenerateUpdateJsonSerializerSettingsMethod -%}
             UpdateJsonSerializerSettings(settings);
+{% endif -%}
             return settings;
         });
     }


### PR DESCRIPTION
If `generateUpdateJsonSerializerSettingsMethod` is set to `false`, and set `jsonSerializerSettingsTransformationMethod` to something, then the generated code will try to invoke the missing `UpdateJsonSerializerSettings` method.