### PR TITLE
Make call to UpdateJsonSerializerSettings conditional on HasBaseClass

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
+++ b/src/NSwag.CodeGeneration.CSharp/Templates/Client.Class.liquid
@@ -36,7 +36,7 @@
 {% if SerializeTypeInformation -%}
             settings.TypeNameHandling = Newtonsoft.Json.TypeNameHandling.Auto;
 {% endif -%}
-{% if GenerateUpdateJsonSerializerSettingsMethod -%}
+{% if GenerateUpdateJsonSerializerSettingsMethod and HasBaseClass == false -%}
             UpdateJsonSerializerSettings(settings);
 {% endif -%}
             return settings;


### PR DESCRIPTION
#2027 was a breaking change in the case you had a base class that included `UpdateJsonSerializerSettings`. This PR address that.